### PR TITLE
doris with pulsar

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -581,6 +581,9 @@ else()
     add_definitions(-DUSE_LIBHDFS3)
 endif()
 
+add_library(libpulsar STATIC IMPORTED)
+set_target_properties(libpulsar PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libpulsar.a)
+
 if (absl_FOUND)
     set(COMMON_THIRDPARTY
         ${COMMON_THIRDPARTY}
@@ -630,6 +633,7 @@ set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} ic)
 set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} clucene-core-static)
 set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} clucene-shared-static)
 set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} clucene-contribs-lib)
+set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} libpulsar)
 
 set(DORIS_DEPENDENCIES ${DORIS_DEPENDENCIES} ${WL_END_GROUP})
 
@@ -717,6 +721,7 @@ set (TEST_LINK_LIBS ${DORIS_LINK_LIBS}
     ${WL_START_GROUP}
     gmock
     gtest
+    libpulsar
     ${WL_END_GROUP}
 )
 

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -474,11 +474,11 @@ DEFINE_mInt64(streaming_load_json_max_mb, "100");
 DEFINE_mInt32(streaming_load_rpc_max_alive_time_sec, "1200");
 // the timeout of a rpc to open the tablet writer in remote BE.
 // short operation time, can set a short timeout
-DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "60");
+DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "300");
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 DEFINE_mBool(tablet_writer_ignore_eovercrowded, "true");
 DEFINE_mBool(exchange_sink_ignore_eovercrowded, "true");
-DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "60");
+DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "300");
 // Whether to enable stream load record function, the default is false.
 // False: disable stream load record
 DEFINE_mBool(enable_stream_load_record, "false");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -594,14 +594,14 @@ DEFINE_Bool(enable_metric_calculator, "true");
 DEFINE_mInt32(max_consumer_num_per_group, "3");
 
 // Max pulsar consumer num in one data consumer group, for routine load.
-DEFINE_mInt32(max_pulsar_consumer_num_per_group, "100");
+DEFINE_mInt32(max_pulsar_consumer_num_per_group, "10");
 
 // pulsar request timeout
-DEFINE_Int32(routine_load_pulsar_timeout_second, "60");
+DEFINE_Int32(routine_load_pulsar_timeout_second, "10");
 
 // the size of thread pool for routine load task.
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
-DEFINE_Int32(routine_load_thread_pool_size, "100");
+DEFINE_Int32(routine_load_thread_pool_size, "10");
 
 // max external scan cache batch count, means cache max_memory_cache_batch_count * batch_size row
 // default is 20, batch_size's default value is 1024 means 20 * 1024 rows will be cached
@@ -781,7 +781,7 @@ DEFINE_String(kafka_debug, "disable");
 // The number of pool siz of routine load consumer.
 // If you meet the error describe in https://github.com/edenhill/librdkafka/issues/3608
 // Change this size to 0 to fix it temporarily.
-DEFINE_Int32(routine_load_consumer_pool_size, "100");
+DEFINE_Int32(routine_load_consumer_pool_size, "10");
 
 // Used in single-stream-multi-table load. When receive a batch of messages from kafka,
 // if the size of batch is more than this threshold, we will request plans for all related tables.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -593,6 +593,12 @@ DEFINE_Bool(enable_metric_calculator, "true");
 // max consumer num in one data consumer group, for routine load
 DEFINE_mInt32(max_consumer_num_per_group, "3");
 
+// Max pulsar consumer num in one data consumer group, for routine load.
+DEFINE_mInt32(max_pulsar_consumer_num_per_group, "10");
+
+// pulsar request timeout
+DEFINE_Int32(routine_load_pulsar_timeout_second, "10");
+
 // the size of thread pool for routine load task.
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
 DEFINE_Int32(routine_load_thread_pool_size, "10");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -594,7 +594,7 @@ DEFINE_Bool(enable_metric_calculator, "true");
 DEFINE_mInt32(max_consumer_num_per_group, "3");
 
 // Max pulsar consumer num in one data consumer group, for routine load.
-DEFINE_mInt32(max_pulsar_consumer_num_per_group, "10");
+DEFINE_mInt32(max_pulsar_consumer_num_per_group, "100");
 
 // pulsar request timeout
 DEFINE_Int32(routine_load_pulsar_timeout_second, "10");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -591,7 +591,7 @@ DEFINE_mInt32(txn_commit_rpc_timeout_ms, "60000");
 DEFINE_Bool(enable_metric_calculator, "true");
 
 // max consumer num in one data consumer group, for routine load
-DEFINE_mInt32(max_consumer_num_per_group, "3");
+DEFINE_mInt32(max_consumer_num_per_group, "100");
 
 // Max pulsar consumer num in one data consumer group, for routine load.
 DEFINE_mInt32(max_pulsar_consumer_num_per_group, "100");

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -227,7 +227,7 @@ DEFINE_mInt32(status_report_interval, "5");
 // if true, each disk will have a separate thread pool for scanner
 DEFINE_Bool(doris_enable_scanner_thread_pool_per_disk, "true");
 // the timeout of a work thread to wait the blocking priority queue to get a task
-DEFINE_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "5000");
+DEFINE_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "500");
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool
 DEFINE_Int32(doris_scanner_thread_pool_thread_num, "48");
@@ -474,11 +474,11 @@ DEFINE_mInt64(streaming_load_json_max_mb, "100");
 DEFINE_mInt32(streaming_load_rpc_max_alive_time_sec, "1200");
 // the timeout of a rpc to open the tablet writer in remote BE.
 // short operation time, can set a short timeout
-DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "300");
+DEFINE_Int32(tablet_writer_open_rpc_timeout_sec, "60");
 // You can ignore brpc error '[E1011]The server is overcrowded' when writing data.
 DEFINE_mBool(tablet_writer_ignore_eovercrowded, "true");
 DEFINE_mBool(exchange_sink_ignore_eovercrowded, "true");
-DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "300");
+DEFINE_mInt32(slave_replica_writer_rpc_timeout_sec, "60");
 // Whether to enable stream load record function, the default is false.
 // False: disable stream load record
 DEFINE_mBool(enable_stream_load_record, "false");
@@ -914,7 +914,7 @@ DEFINE_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
 // This parameter is usually only used when the FE loses connection,
 // and the BE can automatically cancel the relevant fragment after the timeout,
 // so as to avoid occupying the execution thread for a long time.
-DEFINE_mInt32(max_fragment_start_wait_time_seconds, "300");
+DEFINE_mInt32(max_fragment_start_wait_time_seconds, "30");
 
 // Node role tag for backend. Mix role is the default role, and computation role have no
 // any tablet.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -601,7 +601,7 @@ DEFINE_Int32(routine_load_pulsar_timeout_second, "10");
 
 // the size of thread pool for routine load task.
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
-DEFINE_Int32(routine_load_thread_pool_size, "10");
+DEFINE_Int32(routine_load_thread_pool_size, "100");
 
 // max external scan cache batch count, means cache max_memory_cache_batch_count * batch_size row
 // default is 20, batch_size's default value is 1024 means 20 * 1024 rows will be cached
@@ -781,7 +781,7 @@ DEFINE_String(kafka_debug, "disable");
 // The number of pool siz of routine load consumer.
 // If you meet the error describe in https://github.com/edenhill/librdkafka/issues/3608
 // Change this size to 0 to fix it temporarily.
-DEFINE_Int32(routine_load_consumer_pool_size, "10");
+DEFINE_Int32(routine_load_consumer_pool_size, "100");
 
 // Used in single-stream-multi-table load. When receive a batch of messages from kafka,
 // if the size of batch is more than this threshold, we will request plans for all related tables.

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -227,7 +227,7 @@ DEFINE_mInt32(status_report_interval, "5");
 // if true, each disk will have a separate thread pool for scanner
 DEFINE_Bool(doris_enable_scanner_thread_pool_per_disk, "true");
 // the timeout of a work thread to wait the blocking priority queue to get a task
-DEFINE_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "500");
+DEFINE_mInt64(doris_blocking_priority_queue_wait_timeout_ms, "5000");
 // number of scanner thread pool size for olap table
 // and the min thread num of remote scanner thread pool
 DEFINE_Int32(doris_scanner_thread_pool_thread_num, "48");
@@ -591,13 +591,13 @@ DEFINE_mInt32(txn_commit_rpc_timeout_ms, "60000");
 DEFINE_Bool(enable_metric_calculator, "true");
 
 // max consumer num in one data consumer group, for routine load
-DEFINE_mInt32(max_consumer_num_per_group, "100");
+DEFINE_mInt32(max_consumer_num_per_group, "3");
 
 // Max pulsar consumer num in one data consumer group, for routine load.
 DEFINE_mInt32(max_pulsar_consumer_num_per_group, "100");
 
 // pulsar request timeout
-DEFINE_Int32(routine_load_pulsar_timeout_second, "10");
+DEFINE_Int32(routine_load_pulsar_timeout_second, "60");
 
 // the size of thread pool for routine load task.
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
@@ -914,7 +914,7 @@ DEFINE_mInt64(nodechannel_pending_queue_max_bytes, "67108864");
 // This parameter is usually only used when the FE loses connection,
 // and the BE can automatically cancel the relevant fragment after the timeout,
 // so as to avoid occupying the execution thread for a long time.
-DEFINE_mInt32(max_fragment_start_wait_time_seconds, "30");
+DEFINE_mInt32(max_fragment_start_wait_time_seconds, "300");
 
 // Node role tag for backend. Mix role is the default role, and computation role have no
 // any tablet.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -644,6 +644,12 @@ DECLARE_Bool(enable_metric_calculator);
 // max consumer num in one data consumer group, for routine load
 DECLARE_mInt32(max_consumer_num_per_group);
 
+// Max pulsar consumer num in one data consumer group, for routine load.
+DECLARE_mInt32(max_pulsar_consumer_num_per_group);
+
+// pulsar request timeout
+DECLARE_mInt32(routine_load_pulsar_timeout_second);
+
 // the size of thread pool for routine load task.
 // this should be larger than FE config 'max_routine_load_task_num_per_be' (default 5)
 DECLARE_Int32(routine_load_thread_pool_size);

--- a/be/src/io/fs/kafka_consumer_pipe.h
+++ b/be/src/io/fs/kafka_consumer_pipe.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "io/fs/stream_load_pipe.h"
+#include "pulsar/Client.h"
 
 namespace doris {
 namespace io {
@@ -43,5 +44,8 @@ public:
         return append_and_flush(data, size);
     }
 };
+
+using PulsarConsumerPipe = KafkaConsumerPipe;
+
 } // namespace io
 } // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -534,7 +534,6 @@ Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue,
         {
             std::unique_lock<std::mutex> l(_lock);
             if (_cancelled) {
-                LOG(INFO) << "cancel pulsar consumer: " << _id << ", _cancelled: " << _cancelled;
                 break;
             }
         }
@@ -556,16 +555,11 @@ Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue,
             if (received_rows == 0) {
                 _topic_name = msg.get()->getTopicName();
                 LOG(INFO) << "receive first pulsar message. "
-                          << ", len: " << message_str.size()
+                          << "len: " << message_str.size()
                           << ", message id: " << msg_id
                           << ", pulsar consumer: " << _id
                           << ", grp: " << _grp_id
                           << ", topic name: " << _topic_name;
-            } else {
-                LOG(INFO) << "receive pulsar message. "
-                          << ", received_rows: " << received_rows
-                          << ", put_rows: " << put_rows
-                          << ", message id: " << msg_id;
             }
             if (!queue->blocking_put(msg.get())) {
                 // queue is shutdown

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -552,7 +552,7 @@ Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue,
         case pulsar::ResultOk:
             msg_id = msg.get()->getMessageId();
             message_str = msg.get()->getDataAsString();
-            if (received_rows == 0) {
+            if (received_rows >= 0) {
                 _topic_name = msg.get()->getTopicName();
                 LOG(INFO) << "receive first pulsar message: "
                           << ", len: " << message_str.size()

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -534,6 +534,7 @@ Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue,
         {
             std::unique_lock<std::mutex> l(_lock);
             if (_cancelled) {
+                LOG(INFO) << "cancel pulsar consumer: " << _id << ", _cancelled: " << _cancelled;
                 break;
             }
         }
@@ -552,14 +553,19 @@ Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue,
         case pulsar::ResultOk:
             msg_id = msg.get()->getMessageId();
             message_str = msg.get()->getDataAsString();
-            if (received_rows >= 0) {
+            if (received_rows == 0) {
                 _topic_name = msg.get()->getTopicName();
-                LOG(INFO) << "receive first pulsar message: "
+                LOG(INFO) << "receive first pulsar message. "
                           << ", len: " << message_str.size()
                           << ", message id: " << msg_id
                           << ", pulsar consumer: " << _id
                           << ", grp: " << _grp_id
                           << ", topic name: " << _topic_name;
+            } else {
+                LOG(INFO) << "receive pulsar message. "
+                          << ", received_rows: " << received_rows
+                          << ", put_rows: " << put_rows
+                          << ", message id: " << msg_id;
             }
             if (!queue->blocking_put(msg.get())) {
                 // queue is shutdown

--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -452,4 +452,344 @@ bool KafkaDataConsumer::match(std::shared_ptr<StreamLoadContext> ctx) {
     return true;
 }
 
+// init pulsar consumer will only set common configs
+Status PulsarDataConsumer::init(std::shared_ptr<StreamLoadContext> ctx) {
+    std::unique_lock<std::mutex> l(_lock);
+    if (_init) {
+        // this consumer has already been initialized.
+        return Status::OK();
+    }
+
+    pulsar::ClientConfiguration config;
+    for (auto& item : ctx->pulsar_info->properties) {
+        if (item.first == "auth.token") {
+            config.setAuth(pulsar::AuthToken::createWithToken(item.second));
+        } else {
+            LOG(WARNING) << "Config " << item.first << " not supported for now.";
+        }
+
+        _custom_properties.emplace(item.first, item.second);
+    }
+
+    _p_client = new pulsar::Client(_service_url, config);
+
+    VLOG(3) << "finished to init pulsar consumer. " << ctx->brief();
+
+    _init = true;
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::assign_partition(const std::string& partition, std::shared_ptr<StreamLoadContext> ctx,
+                                            int64_t initial_position) {
+    DCHECK(_p_client);
+
+    std::stringstream ss;
+    ss << "consumer: " << _id << ", grp: " << _grp_id << " topic: " << _topic
+       << ", subscription: " << _subscription << ", initial_position: " << initial_position;
+    LOG(INFO) << ss.str();
+
+    // do subscribe
+    pulsar::ConsumerConfiguration conf;
+    conf.setConsumerType(pulsar::ConsumerExclusive);
+    conf.setAckGroupingTimeMs(0); // 设置累积确认立即同步
+    conf.setAckGroupingMaxSize(0);
+
+    pulsar::Result result;
+    result = _p_client->subscribe(partition, _subscription, conf, _p_consumer);
+    if (result != pulsar::ResultOk) {
+        LOG(WARNING) << "PAUSE: failed to create pulsar consumer: " << ctx->brief(true) << ", err: " << result;
+        return Status::InternalError("PAUSE: failed to create pulsar consumer: " +
+                                     std::string(pulsar::strResult(result)));
+    }
+
+    if (initial_position == InitialPosition::LATEST || initial_position == InitialPosition::EARLIEST) {
+        pulsar::InitialPosition p_initial_position = initial_position == InitialPosition::LATEST
+                                                             ? pulsar::InitialPosition::InitialPositionLatest
+                                                             : pulsar::InitialPosition::InitialPositionEarliest;
+        result = _p_consumer.seek(p_initial_position);
+        if (result != pulsar::ResultOk) {
+            LOG(WARNING) << "PAUSE: failed to reset the subscription: " << ctx->brief(true) << ", err: " << result;
+            return Status::InternalError("PAUSE: failed to reset the subscription: " +
+                                         std::string(pulsar::strResult(result)));
+        }
+    }
+
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::group_consume(BlockingQueue<pulsar::Message*>* queue, int64_t max_running_time_ms) {
+    _last_visit_time = time(nullptr);
+    int64_t left_time = max_running_time_ms;
+    LOG(INFO) << "start pulsar consumer: " << _id << ", grp: " << _grp_id << ", max running time(ms): " << left_time;
+
+    int64_t received_rows = 0;
+    int64_t put_rows = 0;
+    Status st = Status::OK();
+    pulsar::MessageId msg_id;
+    std::string message_str;
+    MonotonicStopWatch consumer_watch;
+    MonotonicStopWatch watch;
+    watch.start();
+    while (true) {
+        {
+            std::unique_lock<std::mutex> l(_lock);
+            if (_cancelled) {
+                break;
+            }
+        }
+
+        if (left_time <= 0) {
+            break;
+        }
+
+        bool done = false;
+        auto msg = std::make_unique<pulsar::Message>();
+        // consume 1 message at a time
+        consumer_watch.start();
+        pulsar::Result res = _p_consumer.receive(*(msg.get()), 30000 /* timeout, ms */);
+        consumer_watch.stop();
+        switch (res) {
+        case pulsar::ResultOk:
+            msg_id = msg.get()->getMessageId();
+            message_str = msg.get()->getDataAsString();
+            if (received_rows == 0) {
+                _topic_name = msg.get()->getTopicName();
+                LOG(INFO) << "receive first pulsar message: "
+                          << ", len: " << message_str.size()
+                          << ", message id: " << msg_id
+                          << ", pulsar consumer: " << _id
+                          << ", grp: " << _grp_id
+                          << ", topic name: " << _topic_name;
+            }
+            if (!queue->blocking_put(msg.get())) {
+                // queue is shutdown
+                LOG(INFO) << "queue is shutdown, failed to blocking put"
+                          << ", len: " << message_str.size()
+                          << ", message id: " << msg_id
+                          << ", pulsar consumer: " << _id
+                          << ", grp: " << _grp_id;
+                done = true;
+            } else {
+                ++put_rows;
+            }
+            ++received_rows;
+            msg.release(); // release the ownership, msg will be deleted after being processed
+            break;
+        case pulsar::ResultTimeout:
+            // leave the status as OK, because this may happened
+            // if there is no data in pulsar.
+            LOG(INFO) << "pulsar consumer"
+                      << "[" << _id << "]"
+                      << " consume timeout.";
+            break;
+        default:
+            LOG(WARNING) << "pulsar consumer"
+                         << "[" << _id << "]"
+                         << " consume failed: "
+                         << ", errmsg: " << res;
+            done = true;
+            st = Status::InternalError(pulsar::strResult(res));
+            break;
+        }
+
+        left_time = max_running_time_ms - watch.elapsed_time() / 1000 / 1000;
+        if (done) {
+            break;
+        }
+    }
+
+//    LOG(INFO) << "start do ack of msg_id :" << msg_id;
+//    pulsar::Result ack = _p_consumer.acknowledgeCumulative(msg_id);
+//    if (ack != pulsar::ResultOk) {
+//        LOG(WARNING) << "failed do ack of msg_id :" << msg_id << ", consumer : " << _id;
+//    } else {
+//        LOG(INFO) << "finish do ack of msg_id :" << msg_id << ", consumer : " << _id;
+//    }
+
+    LOG(INFO) << "pulsar consume done: " << _id << ", grp: " << _grp_id << ". cancelled: " << _cancelled
+              << ", left time(ms): " << left_time << ", total cost(ms): " << watch.elapsed_time() / 1000 / 1000
+              << ", consume cost(ms): " << consumer_watch.elapsed_time() / 1000 / 1000
+              << ", received rows: " << received_rows << ", put rows: " << put_rows
+              << ", last message id: " << msg_id << ",len: " << message_str.size();
+
+    return st;
+}
+
+const std::string& PulsarDataConsumer::get_partition() {
+    _last_visit_time = time(nullptr);
+    return _p_consumer.getTopic();
+}
+
+Status PulsarDataConsumer::get_partition_backlog(int64_t* backlog) {
+    _last_visit_time = time(nullptr);
+    pulsar::BrokerConsumerStats broker_consumer_stats;
+    pulsar::Result result = _p_consumer.getBrokerConsumerStats(broker_consumer_stats);
+    if (result != pulsar::ResultOk) {
+        LOG(WARNING) << "Failed to get broker consumer stats: "
+                     << ", err: " << result;
+        return Status::InternalError("Failed to get broker consumer stats: " + std::string(pulsar::strResult(result)));
+    }
+    *backlog = broker_consumer_stats.getMsgBacklog();
+
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::get_topic_partition(std::vector<std::string>* partitions) {
+    _last_visit_time = time(nullptr);
+    pulsar::Result result = _p_client->getPartitionsForTopic(_topic, *partitions);
+    if (result != pulsar::ResultOk) {
+        LOG(WARNING) << "Failed to get partitions for topic: " << _topic << ", err: " << result;
+        return Status::InternalError("Failed to get partitions for topic: " + std::string(pulsar::strResult(result)));
+    }
+
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::cancel(std::shared_ptr<StreamLoadContext> ctx) {
+    std::unique_lock<std::mutex> l(_lock);
+    if (!_init) {
+        return Status::InternalError("consumer is not initialized");
+    }
+
+    _cancelled = true;
+    LOG(INFO) << "pulsar consumer cancelled. " << _id;
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::reset() {
+    std::unique_lock<std::mutex> l(_lock);
+    _cancelled = false;
+    _p_consumer.close();
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::acknowledge_cumulative(pulsar::MessageId& message_id, std::string partition) {
+    //避免重复ack
+    if (_topic_name.empty() || _topic_name.compare(partition) != 0) {
+        return Status::OK();
+    }
+    pulsar::Result res = _p_consumer.acknowledgeCumulative(message_id);
+    if (res != pulsar::ResultOk) {
+        std::stringstream ss;
+        ss << "failed to acknowledge cumulative pulsar message : " << res;
+        LOG(WARNING) << "failed to acknowledge cumulative pulsar message : " << res
+                     << ",pulsar consumer :" << _id
+                     << ",pulsar group :" << _grp_id;
+        return Status::InternalError(ss.str());
+    }
+    LOG(INFO) << "Succeed to acknowledge cumulative pulsar message : " << res
+              << ",pulsar consumer :" << _id
+              << ",pulsar group :" << _grp_id;
+    return Status::OK();
+}
+
+Status PulsarDataConsumer::acknowledge(pulsar::MessageId& message_id, std::string partition) {
+    //避免重复ack
+    if (_topic_name.empty() || _topic_name.compare(partition) != 0) {
+        return Status::OK();
+    }
+    pulsar::Result res = _p_consumer.acknowledge(message_id);
+    if (res != pulsar::ResultOk) {
+        std::stringstream ss;
+        ss << "failed to acknowledge pulsar message : " << res;
+        LOG(WARNING) << "failed to acknowledge pulsar message : " << res
+                     << ",pulsar consumer :" << _id
+                     << ",pulsar group :" << _grp_id;
+        return Status::InternalError(ss.str());
+    }
+    return Status::OK();
+}
+
+bool PulsarDataConsumer::match(std::shared_ptr<StreamLoadContext> ctx) {
+    if (ctx->load_src_type != TLoadSourceType::PULSAR) {
+        return false;
+    }
+    if (_service_url != ctx->pulsar_info->service_url || _topic != ctx->pulsar_info->topic ||
+        _subscription != ctx->pulsar_info->subscription) {
+        return false;
+    }
+    // check properties
+    if (_custom_properties.size() != ctx->pulsar_info->properties.size()) {
+        return false;
+    }
+    for (auto& item : ctx->pulsar_info->properties) {
+        auto it = _custom_properties.find(item.first);
+        if (it == _custom_properties.end() || it->second != item.second) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::string PulsarDataConsumer::substring_prefix_json(std::string data) {
+    // 找到以 "{" 开头的位置
+    size_t startPos = data.find("{\"");
+
+    // 如果找到了，则截取并返回子字符串
+    if (startPos != std::string::npos) {
+        return data.substr(startPos);
+    } else {
+        return data;
+    }
+}
+
+size_t PulsarDataConsumer::len_of_actual_data(const char* data) {
+    size_t length = 0;
+    while (data[length] != '\0') {
+        ++length;
+    }
+    return length;
+}
+
+std::vector<const char*> PulsarDataConsumer::convert_rows(const char* data) {
+    std::vector<const char*> targets;
+    rapidjson::Document source;
+    rapidjson::Document destination;
+    rapidjson::StringBuffer buffer;
+    if(!source.Parse(data).HasParseError()) {
+        if (source.HasMember("events") && source["events"].IsArray()) {
+            const rapidjson::Value& array = source["events"];
+            size_t len = array.Size();
+            for(size_t i = 0; i < len; i++) {
+                destination.SetObject();
+                for (auto& member : source.GetObject()) {
+                    const char* key = member.name.GetString();
+                    if (std::strcmp(key, "events") != 0) {
+                        rapidjson::Value keyName(key, destination.GetAllocator());
+                        rapidjson::Value sourceValue(rapidjson::kObjectType);
+                        sourceValue.CopyFrom(source[key], destination.GetAllocator());
+                        destination.AddMember(keyName, sourceValue, destination.GetAllocator());
+                    } else {
+                        rapidjson::Value& object = const_cast<rapidjson::Value&>(array[i]);
+                        rapidjson::Value eventName("event", destination.GetAllocator());
+                        destination.AddMember(eventName, object, destination.GetAllocator());
+                    }
+                }
+
+                buffer.Clear();
+                rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                destination.Accept(writer);
+
+                size_t buffer_size = buffer.GetSize();
+                char* dest_string = new char[buffer_size + 1];
+                std::memcpy(dest_string, buffer.GetString(), buffer_size);
+                dest_string[buffer_size] = '\0';
+                targets.push_back(dest_string);
+
+                destination.RemoveAllMembers();
+            }
+        } else {
+            targets.push_back(data);
+        }
+    } else {
+        targets.push_back(data);
+    }
+    destination.Clear();
+    rapidjson::Document().Swap(destination);
+    source.Clear();
+    rapidjson::Document().Swap(source);
+    return targets;
+}
+
 } // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -33,6 +33,8 @@
 #include "librdkafka/rdkafkacpp.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "util/uid_util.h"
+#include "pulsar/Client.h"
+#include "io/fs/kafka_consumer_pipe.h"
 
 namespace doris {
 
@@ -163,6 +165,66 @@ private:
 
     KafkaEventCb _k_event_cb;
     RdKafka::KafkaConsumer* _k_consumer = nullptr;
+};
+
+class PulsarDataConsumer : public DataConsumer {
+public:
+    PulsarDataConsumer(std::shared_ptr<StreamLoadContext> ctx)
+            : DataConsumer(),
+              _service_url(ctx->pulsar_info->service_url),
+              _topic(ctx->pulsar_info->topic),
+              _subscription(ctx->pulsar_info->subscription) {}
+
+    ~PulsarDataConsumer() override {
+        VLOG(3) << "deconstruct pulsar client";
+        if (_p_client) {
+            _p_client->close();
+            delete _p_client;
+            _p_client = nullptr;
+        }
+    }
+
+    enum InitialPosition { LATEST, EARLIEST };
+
+    Status init(std::shared_ptr<StreamLoadContext> ctx) override;
+    Status assign_partition(const std::string& partition, std::shared_ptr<StreamLoadContext> ctx, int64_t initial_position = -1);
+    // TODO(cmy): currently do not implement single consumer start method, using group_consume
+    Status consume(std::shared_ptr<StreamLoadContext> ctx) override { return Status::OK(); }
+    Status cancel(std::shared_ptr<StreamLoadContext> ctx) override;
+    // reassign partition topics
+    Status reset() override;
+    bool match(std::shared_ptr<StreamLoadContext> ctx) override;
+    // acknowledge pulsar message
+    Status acknowledge_cumulative(pulsar::MessageId& message_id, std::string partition);
+
+    Status acknowledge(pulsar::MessageId& message_id, std::string partition);
+
+    // start the consumer and put msgs to queue
+    Status group_consume(BlockingQueue<pulsar::Message*>* queue, int64_t max_running_time_ms);
+
+    // get the partitions of the topic
+    Status get_topic_partition(std::vector<std::string>* partitions);
+
+    // get backlog num of partition
+    Status get_partition_backlog(int64_t* backlog);
+
+    const std::string& get_partition();
+
+    std::string substring_prefix_json(std::string data);
+
+    size_t len_of_actual_data(const char* data);
+
+    std::vector<const char*> convert_rows(const char* data);
+private:
+    std::string _service_url;
+    std::string _topic;
+    std::string _subscription;
+    std::unordered_map<std::string, std::string> _custom_properties;
+    std::string _topic_name;
+
+    pulsar::Client* _p_client = nullptr;
+    pulsar::Consumer _p_consumer;
+    std::shared_ptr<io::PulsarConsumerPipe> _p_consumer_pipe;
 };
 
 } // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -243,6 +243,9 @@ PulsarDataConsumerGroup::~PulsarDataConsumerGroup() {
 
 Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx) {
     Status result_st = Status::OK();
+
+    LOG(INFO) << "group _consumers size is: " << _consumers.size();
+
     // start all consumers
     for (auto& consumer : _consumers) {
         if (!_thread_pool.offer([this, consumer, capture0 = &_queue, capture1 = ctx->max_interval_s * 1000,
@@ -361,7 +364,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
             std::string filter_data = substring_prefix_json(msg->getDataAsString());
             std::vector<const char*>  rows = convert_rows(filter_data.c_str());
 
-            VLOG(3)   << "get pulsar message:" << msg->getDataAsString()
+            LOG(INFO) << "get pulsar message:" << msg->getDataAsString()
                       << ", partition: " << partition << ", message id: " << msg_id
                       << ", len: " << len << ", size: " << msg->getDataAsString().size();
 

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -359,9 +359,13 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
                 }
             }
 
-
             //filter invalid prefix of json
             std::string filter_data = substring_prefix_json(msg->getDataAsString());
+            bool is_filter = is_filter_event_ids(filter_data);
+            if (!is_filter) {
+                left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
+                continue;
+            }
             std::vector<const char*>  rows = convert_rows(filter_data.c_str());
 
             VLOG(3)   << "get pulsar message:" << msg->getDataAsString()
@@ -531,6 +535,16 @@ std::vector<const char*> PulsarDataConsumerGroup::convert_rows(const char* data)
     source.Clear();
     rapidjson::Document().Swap(source);
     return targets;
+}
+
+bool PulsarDataConsumerGroup::is_filter_event_ids(std::string data) {
+    for (auto& event_id : _filter_event_ids) {
+        std::string filter_json = "\"event_id\":\"" + event_id + "\"";
+        if (data.find(filter_json) != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace doris

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -23,9 +23,9 @@
 #include <ostream>
 #include <string>
 #include <utility>
+#include <chrono> // IWYU pragma: keep
 
 #include "common/logging.h"
-#include "io/fs/kafka_consumer_pipe.h"
 #include "librdkafka/rdkafkacpp.h"
 #include "runtime/routine_load/data_consumer.h"
 #include "runtime/stream_load/stream_load_context.h"
@@ -202,6 +202,333 @@ void KafkaDataConsumerGroup::actual_consume(std::shared_ptr<DataConsumer> consum
     Status st = std::static_pointer_cast<KafkaDataConsumer>(consumer)->group_consume(
             queue, max_running_time_ms);
     cb(st);
+}
+
+Status PulsarDataConsumerGroup::assign_topic_partitions(std::shared_ptr<StreamLoadContext> ctx) {
+    DCHECK(ctx->pulsar_info);
+    DCHECK(_consumers.size() >= 1);
+    // Cumulative acknowledgement when consuming partitioned topics is not supported by pulsar
+    DCHECK(_consumers.size() == ctx->pulsar_info->partitions.size());
+
+    // assign partition to consumers
+    int consumer_size = _consumers.size();
+    for (int i = 0; i < consumer_size; ++i) {
+        auto iter = ctx->pulsar_info->initial_positions.find(ctx->pulsar_info->partitions[i]);
+        if (iter != ctx->pulsar_info->initial_positions.end()) {
+            RETURN_IF_ERROR(std::static_pointer_cast<PulsarDataConsumer>(_consumers[i])
+                                    ->assign_partition(ctx->pulsar_info->partitions[i], ctx, iter->second));
+        } else {
+            RETURN_IF_ERROR(std::static_pointer_cast<PulsarDataConsumer>(_consumers[i])
+                                    ->assign_partition(ctx->pulsar_info->partitions[i], ctx));
+        }
+    }
+
+    return Status::OK();
+}
+
+PulsarDataConsumerGroup::~PulsarDataConsumerGroup() {
+    // clean the msgs left in queue
+    _queue.shutdown();
+    while (true) {
+        pulsar::Message* msg;
+        if (_queue.blocking_get(&msg)) {
+            delete msg;
+            msg = nullptr;
+        } else {
+            break;
+        }
+    }
+    DCHECK(_queue.get_size() == 0);
+}
+
+Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx) {
+    Status result_st = Status::OK();
+    // start all consumers
+    for (auto& consumer : _consumers) {
+        if (!_thread_pool.offer([this, consumer, capture0 = &_queue, capture1 = ctx->max_interval_s * 1000,
+                capture2 = [this, &result_st](const Status& st) {
+                 std::unique_lock<std::mutex> lock(_mutex);
+                 _counter--;
+                 VLOG(1) << "group counter is: " << _counter << ", grp: " << _grp_id;
+                 if (_counter == 0) {
+                     _queue.shutdown();
+                     LOG(INFO)
+                             << "all consumers are finished. shutdown queue. group id: " << _grp_id;
+                 }
+                 if (result_st.ok() && !st.ok()) {
+                     result_st = st;
+                 }
+                }] { actual_consume(consumer, capture0, capture1, capture2); })) {
+            LOG(WARNING) << "failed to submit data consumer: " << consumer->id() << ", group id: " << _grp_id;
+            return Status::InternalError("failed to submit data consumer");
+        } else {
+            VLOG(1) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
+        }
+    }
+
+    // consuming from queue and put data to stream load pipe
+    int64_t left_time = ctx->max_interval_s * 1000;
+    int64_t received_rows = 0;
+    int64_t left_bytes = ctx->max_batch_size;
+
+    std::shared_ptr<io::PulsarConsumerPipe> pulsar_pipe = std::static_pointer_cast<io::PulsarConsumerPipe>(ctx->body_sink);
+
+    LOG(INFO) << "start consumer group: " << _grp_id << ". max time(ms): " << left_time
+              << ", batch size: " << left_bytes << ". " << ctx->brief();
+
+    // copy one
+    std::map<std::string, pulsar::MessageId> ack_offset = ctx->pulsar_info->ack_offset;
+    std::set<std::string> exist_repeated_ack;
+    for (auto& kv : ack_offset) {
+        exist_repeated_ack.insert(kv.first);
+    }
+
+    //improve performance
+    Status (io::PulsarConsumerPipe::*append_data)(const char* data, size_t size);
+    if (ctx->format == TFileFormatType::FORMAT_JSON) {
+        append_data = &io::PulsarConsumerPipe::append_json;
+    } else {
+        append_data = &io::PulsarConsumerPipe::append_with_line_delimiter;
+    }
+
+    MonotonicStopWatch watch;
+    watch.start();
+    bool eos = false;
+    while (true) {
+        if (eos || left_time <= 0 || left_bytes <= 0) {
+            LOG(INFO) << "consumer group done: " << _grp_id
+                      << ". consume time(ms)=" << ctx->max_interval_s * 1000 - left_time
+                      << ", received rows=" << received_rows << ", received bytes=" << ctx->max_batch_size - left_bytes
+                      << ", eos: " << eos << ", left_time: " << left_time << ", left_bytes: " << left_bytes
+                      << ", blocking get time(us): " << _queue.total_get_wait_time() / 1000
+                      << ", blocking put time(us): " << _queue.total_put_wait_time() / 1000;
+
+            // shutdown queue
+            _queue.shutdown();
+            // cancel all consumers
+            for (auto& consumer : _consumers) {
+                static_cast<void>(consumer->cancel(ctx));
+            }
+
+            // waiting all threads finished
+            _thread_pool.shutdown();
+            _thread_pool.join();
+
+            if (!result_st.ok()) {
+                // some consumers encounter errors, cancel this task
+                LOG(WARNING) << "Failed. Cancelled append msg to pipe. grp: " << _grp_id;
+                pulsar_pipe->cancel(result_st.to_string());
+                return result_st;
+            }
+
+            if (left_bytes == ctx->max_batch_size) {
+                // nothing to be consumed, we have to cancel it, because
+                // we do not allow finishing stream load pipe without data
+                LOG(WARNING) << "Cancelled append msg to pulsar pipe. grp: " << _grp_id;
+                pulsar_pipe->cancel("Cancelled");
+                return Status::InternalError("Cancelled");
+            } else {
+                DCHECK(left_bytes < ctx->max_batch_size);
+                static_cast<void>(pulsar_pipe->finish());
+                ctx->pulsar_info->ack_offset = std::move(ack_offset);
+                ctx->receive_bytes = ctx->max_batch_size - left_bytes;
+                get_backlog_nums(ctx);
+//                acknowledge_cumulative(ctx);
+                return Status::OK();
+            }
+        }
+
+        pulsar::Message* msg;
+        bool res = _queue.blocking_get(&msg);
+        if (res) {
+            std::string partition = msg->getTopicName();
+            pulsar::MessageId msg_id = msg->getMessageId();
+            std::size_t len = msg->getLength();
+
+            // avoid repeated ack
+            if (!exist_repeated_ack.empty()) {
+                if (ack_offset.find(partition) != ack_offset.end() && ack_offset[partition] >= msg_id) {
+                    LOG(INFO) << "Pass repeated message id: " << msg_id;
+                    acknowledge(msg_id, partition);
+                    left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
+                    continue;
+                } else if (exist_repeated_ack.find(partition) != exist_repeated_ack.end()) {
+                    exist_repeated_ack.erase(partition);
+                }
+            }
+
+
+            //filter invalid prefix of json
+            std::string filter_data = substring_prefix_json(msg->getDataAsString());
+            std::vector<const char*>  rows = convert_rows(filter_data.c_str());
+
+            VLOG(3)   << "get pulsar message:" << msg->getDataAsString()
+                      << ", partition: " << partition << ", message id: " << msg_id
+                      << ", len: " << len << ", size: " << msg->getDataAsString().size();
+
+            Status st;
+            for(const char* row : rows) {
+                size_t row_len = len_of_actual_data(row);
+                st = (pulsar_pipe.get()->*append_data)(row, row_len);
+                if (!st.ok()) {
+                    LOG(WARNING) << "failed to append msg to pipe. grp: " << _grp_id << ", row =" << row;
+                    break;
+                }
+            }
+
+           if (st.ok()) {
+               received_rows++;
+               // len of receive origin message from pulsar
+               left_bytes -= len;
+               if (ack_offset[partition] >= msg_id) {
+                  LOG(WARNING) << "find repeated message id: " << msg_id;
+               }
+               ack_offset[partition] = msg_id;
+//               acknowledge(msg_id, partition);
+               VLOG(3) << "load message id: " << msg_id;
+           } else {
+               // failed to append this msg, we must stop
+               LOG(WARNING) << "failed to append msg to pipe. grp: " << _grp_id << ", errmsg=" << st.to_string();
+               eos = true;
+               {
+                   std::unique_lock<std::mutex> lock(_mutex);
+                   if (result_st.ok()) {
+                       result_st = st;
+                   }
+               }
+           }
+           for(const char* row : rows) {
+                delete[] row;
+           }
+           rows.clear();
+           delete msg;
+        } else {
+            // queue is empty and shutdown
+            eos = true;
+        }
+
+        left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
+    }
+
+    exist_repeated_ack.clear();
+
+    return Status::OK();
+}
+
+void PulsarDataConsumerGroup::actual_consume(const std::shared_ptr<DataConsumer>& consumer,
+                                             BlockingQueue<pulsar::Message*>* queue, int64_t max_running_time_ms,
+                                             const ConsumeFinishCallback& cb) {
+    Status st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->group_consume(queue, max_running_time_ms);
+    cb(st);
+}
+
+void PulsarDataConsumerGroup::get_backlog_nums(std::shared_ptr<StreamLoadContext> ctx) {
+    for (auto& consumer : _consumers) {
+        // get backlog num
+        int64_t backlog_num;
+        Status st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->get_partition_backlog(&backlog_num);
+        if (!st.ok()) {
+            LOG(WARNING) << st.to_string();
+        } else {
+            ctx->pulsar_info
+                    ->partition_backlog[std::static_pointer_cast<PulsarDataConsumer>(consumer)->get_partition()] =
+                    backlog_num;
+        }
+    }
+}
+
+Status PulsarDataConsumerGroup::acknowledge_cumulative(std::shared_ptr<StreamLoadContext> ctx) {
+    Status result_st = Status::OK();
+    for (auto& kv : ctx->pulsar_info->ack_offset) {
+        for (auto& consumer : _consumers) {
+            // do cumulative ack
+            Status st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->acknowledge_cumulative(kv.second, kv.first);
+            if (!st.ok()) {
+                result_st = st;
+            }
+        }
+    }
+    return result_st;
+}
+
+void PulsarDataConsumerGroup::acknowledge(pulsar::MessageId& message_id, std::string partition) {
+    for (auto& consumer : _consumers) {
+        // do ack
+        Status st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->acknowledge(message_id, partition);
+        if (!st.ok()) {
+            LOG(WARNING) << "failed to ack message id: " << message_id << ", consumer: " << consumer;
+        }
+    }
+}
+
+std::string PulsarDataConsumerGroup::substring_prefix_json(std::string data) {
+    // 找到以 "{" 开头的位置
+    size_t startPos = data.find("{\"");
+
+    // 如果找到了，则截取并返回子字符串
+    if (startPos != std::string::npos) {
+        return data.substr(startPos);
+    } else {
+        return data;
+    }
+}
+
+size_t PulsarDataConsumerGroup::len_of_actual_data(const char* data) {
+    size_t length = 0;
+    while (data[length] != '\0') {
+        ++length;
+    }
+    return length;
+}
+
+std::vector<const char*> PulsarDataConsumerGroup::convert_rows(const char* data) {
+    std::vector<const char*> targets;
+    rapidjson::Document source;
+    rapidjson::Document destination;
+    rapidjson::StringBuffer buffer;
+    if(!source.Parse(data).HasParseError()) {
+        if (source.HasMember("events") && source["events"].IsArray()) {
+            const rapidjson::Value& array = source["events"];
+            size_t len = array.Size();
+            for(size_t i = 0; i < len; i++) {
+                destination.SetObject();
+                for (auto& member : source.GetObject()) {
+                    const char* key = member.name.GetString();
+                    if (std::strcmp(key, "events") != 0) {
+                        rapidjson::Value keyName(key, destination.GetAllocator());
+                        rapidjson::Value sourceValue(rapidjson::kObjectType);
+                        sourceValue.CopyFrom(source[key], destination.GetAllocator());
+                        destination.AddMember(keyName, sourceValue, destination.GetAllocator());
+                    } else {
+                        rapidjson::Value& object = const_cast<rapidjson::Value&>(array[i]);
+                        rapidjson::Value eventName("event", destination.GetAllocator());
+                        destination.AddMember(eventName, object, destination.GetAllocator());
+                    }
+                }
+
+                rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+                destination.Accept(writer);
+
+                size_t buffer_size = buffer.GetSize();
+                char* dest_string = new char[buffer_size + 1];
+                std::memcpy(dest_string, buffer.GetString(), buffer_size);
+                dest_string[buffer_size] = '\0';
+                targets.push_back(dest_string);
+
+                buffer.Clear();
+                destination.Clear();
+            }
+        } else {
+            targets.push_back(data);
+        }
+    } else {
+        LOG(WARNING) << "Failed to convert rows, pass json: " << data;
+    }
+    destination.Clear();
+    rapidjson::Document().Swap(destination);
+    source.Clear();
+    rapidjson::Document().Swap(source);
+    return targets;
 }
 
 } // namespace doris

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -252,7 +252,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
                 capture2 = [this, &result_st](const Status& st) {
                  std::unique_lock<std::mutex> lock(_mutex);
                  _counter--;
-                 VLOG(1) << "group counter is: " << _counter << ", grp: " << _grp_id;
+                 LOG(INFO) << "group counter is: " << _counter << ", grp: " << _grp_id;
                  if (_counter == 0) {
                      _queue.shutdown();
                      LOG(INFO)
@@ -265,7 +265,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
             LOG(WARNING) << "failed to submit data consumer: " << consumer->id() << ", group id: " << _grp_id;
             return Status::InternalError("failed to submit data consumer");
         } else {
-            VLOG(1) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
+            LOG(INFO) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
         }
     }
 

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -276,12 +276,11 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
     LOG(INFO) << "start consumer group: " << _grp_id << ". max time(ms): " << left_time
               << ", batch size: " << left_bytes << ". " << ctx->brief();
 
+    std::map<std::string, pulsar::MessageId> ack_offset;
+
     // copy one
-    std::map<std::string, pulsar::MessageId> ack_offset = ctx->pulsar_info->ack_offset;
+    std::map<std::string, pulsar::MessageId> last_ack_offset = ctx->pulsar_info->ack_offset;
     std::set<std::string> exist_repeated_ack;
-    for (auto& kv : ack_offset) {
-        exist_repeated_ack.insert(kv.first);
-    }
 
     //improve performance
     Status (io::PulsarConsumerPipe::*append_data)(const char* data, size_t size);
@@ -346,14 +345,14 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
             std::size_t len = msg->getLength();
 
             // avoid repeated ack
-            if (!exist_repeated_ack.empty()) {
-                if (ack_offset.find(partition) != ack_offset.end() && ack_offset[partition] >= msg_id) {
+            if (exist_repeated_ack.find(partition) == exist_repeated_ack.end()) {
+                if (last_ack_offset.find(partition) != last_ack_offset.end() && last_ack_offset[partition] >= msg_id) {
                     LOG(INFO) << "Pass repeated message id: " << msg_id;
-                    acknowledge(msg_id, partition);
+//                    acknowledge(msg_id, partition);
                     left_time = ctx->max_interval_s * 1000 - watch.elapsed_time() / 1000 / 1000;
                     continue;
-                } else if (exist_repeated_ack.find(partition) != exist_repeated_ack.end()) {
-                    exist_repeated_ack.erase(partition);
+                } else {
+                    exist_repeated_ack.insert(partition);
                 }
             }
 

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -541,6 +541,8 @@ bool PulsarDataConsumerGroup::is_filter_event_ids(std::string data) {
     for (auto& event_id : _filter_event_ids) {
         std::string filter_json = "\"event_id\":\"" + event_id + "\"";
         if (data.find(filter_json) != std::string::npos) {
+            LOG(INFO) << "get pulsar message: " << data
+                      << "find event_id: " << filter_json;
             return true;
         }
     }

--- a/be/src/runtime/routine_load/data_consumer_group.cpp
+++ b/be/src/runtime/routine_load/data_consumer_group.cpp
@@ -252,7 +252,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
                 capture2 = [this, &result_st](const Status& st) {
                  std::unique_lock<std::mutex> lock(_mutex);
                  _counter--;
-                 LOG(INFO) << "group counter is: " << _counter << ", grp: " << _grp_id;
+                 VLOG(1) << "group counter is: " << _counter << ", grp: " << _grp_id;
                  if (_counter == 0) {
                      _queue.shutdown();
                      LOG(INFO)
@@ -265,7 +265,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
             LOG(WARNING) << "failed to submit data consumer: " << consumer->id() << ", group id: " << _grp_id;
             return Status::InternalError("failed to submit data consumer");
         } else {
-            LOG(INFO) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
+            VLOG(1) << "submit a data consumer: " << consumer->id() << ", group id: " << _grp_id;
         }
     }
 
@@ -364,7 +364,7 @@ Status PulsarDataConsumerGroup::start_all(std::shared_ptr<StreamLoadContext> ctx
             std::string filter_data = substring_prefix_json(msg->getDataAsString());
             std::vector<const char*>  rows = convert_rows(filter_data.c_str());
 
-            LOG(INFO) << "get pulsar message:" << msg->getDataAsString()
+            VLOG(3)   << "get pulsar message:" << msg->getDataAsString()
                       << ", partition: " << partition << ", message id: " << msg_id
                       << ", len: " << len << ", size: " << msg->getDataAsString().size();
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -108,8 +108,9 @@ private:
 class PulsarDataConsumerGroup : public DataConsumerGroup {
 public:
     PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500),
-    _filter_event_ids{"010101003","010106001","010601002","011101001","011360003","011410000","011410004",
-    "012101013","017401046","017401057","017401076","020201001","0102044","0105002","0105084"} {}
+    _filter_event_ids{"\"010101003\"","\"010106001\"","\"010601002\"","\"011101001\"","\"011360003\"","\"011410000\"",
+    "\"011410004\"","\"012101013\"","\"017401046\"","\"017401057\"","\"017401076\"","\"020201001\"","\"0102044\"",
+    "\"0105002\"","\"0105084\""} {}
 
     ~PulsarDataConsumerGroup() override;
 
@@ -142,7 +143,7 @@ private:
     // blocking queue to receive msgs from all consumers
     BlockingQueue<pulsar::Message*> _queue;
 
-    std::vector<std::string> _filter_event_ids;
+    std::vector<const char*> _filter_event_ids;
 };
 
 } // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(6, 10, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(100, 100, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(10, 100, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 
@@ -85,7 +85,7 @@ protected:
 // for kafka
 class KafkaDataConsumerGroup : public DataConsumerGroup {
 public:
-    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
+    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(5000) {}
 
     virtual ~KafkaDataConsumerGroup();
 
@@ -107,7 +107,7 @@ private:
 // for pulsar
 class PulsarDataConsumerGroup : public DataConsumerGroup {
 public:
-    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
+    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(5000) {}
 
     ~PulsarDataConsumerGroup() override;
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(6, 10, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(10, 100, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(100, 200, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -137,7 +137,7 @@ private:
     // acknowledge pulsar message
     void acknowledge(pulsar::MessageId& message_id, std::string partition);
 
-    bool is_filter_event_ids(std::string data);
+    bool is_filter_event_ids(const char* data);
 
 private:
     // blocking queue to receive msgs from all consumers

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(100, 200, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 
@@ -85,7 +85,7 @@ protected:
 // for kafka
 class KafkaDataConsumerGroup : public DataConsumerGroup {
 public:
-    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(5000) {}
+    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
 
     virtual ~KafkaDataConsumerGroup();
 
@@ -107,7 +107,7 @@ private:
 // for pulsar
 class PulsarDataConsumerGroup : public DataConsumerGroup {
 public:
-    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(5000) {}
+    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
 
     ~PulsarDataConsumerGroup() override;
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(100, 100, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -46,7 +46,7 @@ public:
     typedef std::function<void(const Status&)> ConsumeFinishCallback;
 
     DataConsumerGroup()
-            : _grp_id(UniqueId::gen_uid()), _thread_pool(3, 10, "data_consumer"), _counter(0) {}
+            : _grp_id(UniqueId::gen_uid()), _thread_pool(6, 10, "data_consumer"), _counter(0) {}
 
     virtual ~DataConsumerGroup() { _consumers.clear(); }
 
@@ -85,7 +85,7 @@ protected:
 // for kafka
 class KafkaDataConsumerGroup : public DataConsumerGroup {
 public:
-    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
+    KafkaDataConsumerGroup() : DataConsumerGroup(), _queue(1000) {}
 
     virtual ~KafkaDataConsumerGroup();
 
@@ -107,7 +107,7 @@ private:
 // for pulsar
 class PulsarDataConsumerGroup : public DataConsumerGroup {
 public:
-    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500),
+    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(1000),
     _filter_event_ids{"\"010101003\"","\"010106001\"","\"010601002\"","\"011101001\"","\"011360003\"","\"011410000\"",
     "\"011410004\"","\"012101013\"","\"017401046\"","\"017401057\"","\"017401076\"","\"020201001\"","\"0102044\"",
     "\"0105002\"","\"0105084\""} {}

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -107,7 +107,9 @@ private:
 // for pulsar
 class PulsarDataConsumerGroup : public DataConsumerGroup {
 public:
-    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500) {}
+    PulsarDataConsumerGroup() : DataConsumerGroup(), _queue(500),
+    _filter_event_ids{"010101003","010106001","010601002","011101001","011360003","011410000","011410004",
+    "012101013","017401046","017401057","017401076","020201001","0102044","0105002","0105084"} {}
 
     ~PulsarDataConsumerGroup() override;
 
@@ -134,9 +136,13 @@ private:
     // acknowledge pulsar message
     void acknowledge(pulsar::MessageId& message_id, std::string partition);
 
+    bool is_filter_event_ids(std::string data);
+
 private:
     // blocking queue to receive msgs from all consumers
     BlockingQueue<pulsar::Message*> _queue;
+
+    std::vector<std::string> _filter_event_ids;
 };
 
 } // end namespace doris

--- a/be/src/runtime/routine_load/data_consumer_pool.cpp
+++ b/be/src/runtime/routine_load/data_consumer_pool.cpp
@@ -35,6 +35,7 @@
 #include "runtime/routine_load/data_consumer_group.h"
 #include "runtime/stream_load/stream_load_context.h"
 #include "util/uid_util.h"
+#include "data_consumer.h"
 
 namespace doris {
 
@@ -63,6 +64,9 @@ Status DataConsumerPool::get_consumer(std::shared_ptr<StreamLoadContext> ctx,
     case TLoadSourceType::KAFKA:
         consumer = std::make_shared<KafkaDataConsumer>(ctx);
         break;
+    case TLoadSourceType::PULSAR:
+        consumer = std::make_shared<PulsarDataConsumer>(ctx);
+        break;
     default:
         return Status::InternalError("PAUSE: unknown routine load task type: {}", ctx->load_type);
     }
@@ -77,31 +81,59 @@ Status DataConsumerPool::get_consumer(std::shared_ptr<StreamLoadContext> ctx,
 
 Status DataConsumerPool::get_consumer_grp(std::shared_ptr<StreamLoadContext> ctx,
                                           std::shared_ptr<DataConsumerGroup>* ret) {
-    if (ctx->load_src_type != TLoadSourceType::KAFKA) {
+    if (ctx->load_src_type != TLoadSourceType::KAFKA && ctx->load_src_type != TLoadSourceType::PULSAR) {
         return Status::InternalError(
-                "PAUSE: Currently only support consumer group for Kafka data source");
-    }
-    DCHECK(ctx->kafka_info);
-
-    if (ctx->kafka_info->begin_offset.size() == 0) {
-        return Status::InternalError("PAUSE: The size of begin_offset of task should not be 0.");
+                "PAUSE: Currently only support consumer group for Kafka or Pulsar data source");
     }
 
-    std::shared_ptr<KafkaDataConsumerGroup> grp = std::make_shared<KafkaDataConsumerGroup>();
+    if (ctx->load_src_type == TLoadSourceType::KAFKA) {
+        DCHECK(ctx->kafka_info);
 
-    // one data consumer group contains at least one data consumers.
-    int max_consumer_num = config::max_consumer_num_per_group;
-    size_t consumer_num = std::min((size_t)max_consumer_num, ctx->kafka_info->begin_offset.size());
+        if (ctx->kafka_info->begin_offset.size() == 0) {
+            return Status::InternalError("PAUSE: The size of begin_offset of task should not be 0.");
+        }
 
-    for (int i = 0; i < consumer_num; ++i) {
-        std::shared_ptr<DataConsumer> consumer;
-        RETURN_IF_ERROR(get_consumer(ctx, &consumer));
-        grp->add_consumer(consumer);
+        std::shared_ptr<KafkaDataConsumerGroup> grp = std::make_shared<KafkaDataConsumerGroup>();
+
+        // one data consumer group contains at least one data consumers.
+        int max_consumer_num = config::max_consumer_num_per_group;
+        size_t consumer_num = std::min((size_t)max_consumer_num, ctx->kafka_info->begin_offset.size());
+
+        for (int i = 0; i < consumer_num; ++i) {
+            std::shared_ptr<DataConsumer> consumer;
+            RETURN_IF_ERROR(get_consumer(ctx, &consumer));
+            grp->add_consumer(consumer);
+        }
+
+        LOG(INFO) << "get consumer group " << grp->grp_id() << " with " << consumer_num << " consumers";
+        *ret = grp;
+        return Status::OK();
+    } else {
+        DCHECK(ctx->pulsar_info);
+        DCHECK_GE(ctx->pulsar_info->partitions.size(), 1);
+
+        // Cumulative acknowledge is not supported for multiple topic subscribtion,
+        // so one consumer can only subscribe one topic/partition
+        int max_consumer_num = config::max_pulsar_consumer_num_per_group;
+        if (max_consumer_num < ctx->pulsar_info->partitions.size()) {
+          return Status::InternalError(
+                  "PAUSE: Partition num is more than max consumer num in one data consumer group on some BEs, please "
+                  "increase max_pulsar_consumer_num_per_group from BE side or just add more BEs");
+        }
+        size_t consumer_num = ctx->pulsar_info->partitions.size();
+
+        std::shared_ptr<PulsarDataConsumerGroup> grp = std::make_shared<PulsarDataConsumerGroup>();
+
+        for (int i = 0; i < consumer_num; ++i) {
+          std::shared_ptr<DataConsumer> consumer;
+          RETURN_IF_ERROR(get_consumer(ctx, &consumer));
+          grp->add_consumer(consumer);
+        }
+
+        LOG(INFO) << "get consumer group " << grp->grp_id() << " with " << consumer_num << " consumers";
+        *ret = grp;
+        return Status::OK();
     }
-
-    LOG(INFO) << "get consumer group " << grp->grp_id() << " with " << consumer_num << " consumers";
-    *ret = grp;
-    return Status::OK();
 }
 
 void DataConsumerPool::return_consumer(std::shared_ptr<DataConsumer> consumer) {

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -62,7 +62,7 @@ using namespace ErrorCode;
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(routine_load_task_count, MetricUnit::NOUNIT);
 
-std::map<std::string, pulsar::MessageId*> RoutineLoadTaskExecutor::_last_ack_offset;
+std::map<std::string, std::unique_ptr<pulsar::MessageId>> RoutineLoadTaskExecutor::_last_ack_offset;
 std::mutex RoutineLoadTaskExecutor::_ack_mutex;
 
 RoutineLoadTaskExecutor::RoutineLoadTaskExecutor(ExecEnv* exec_env)

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -575,14 +575,14 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
     return Status::OK();
 }
 
-static void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
+void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
         RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }
 }
 
-static void RoutineLoadTaskExecutor::copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
+void RoutineLoadTaskExecutor::copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     if (!RoutineLoadTaskExecutor::_last_ack_offset.empty()) {
         map = RoutineLoadTaskExecutor::_last_ack_offset;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -575,14 +575,14 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
     return Status::OK();
 }
 
-static void copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
+static void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
         RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }
 }
 
-static void copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
+static void RoutineLoadTaskExecutor::copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     if (!RoutineLoadTaskExecutor::_last_ack_offset.empty()) {
         map = RoutineLoadTaskExecutor::_last_ack_offset;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -583,7 +583,8 @@ void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::Mess
     for (auto& kv : map) {
         if (RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first) !=
                 RoutineLoadTaskExecutor::_last_ack_offset.end()) {
-            delete RoutineLoadTaskExecutor::_last_ack_offset[kv.first]; // 如果不为空，则释放资源
+            pulsar::Message* msg = &RoutineLoadTaskExecutor::_last_ack_offset[kv.first];
+            delete msg; // 如果不为空，则释放资源
         }
         RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -62,6 +62,9 @@ using namespace ErrorCode;
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(routine_load_task_count, MetricUnit::NOUNIT);
 
+std::map<std::string, pulsar::MessageId> RoutineLoadTaskExecutor::_last_ack_offset;
+std::mutex RoutineLoadTaskExecutor::_ack_mutex;
+
 RoutineLoadTaskExecutor::RoutineLoadTaskExecutor(ExecEnv* exec_env)
         : _exec_env(exec_env),
           _thread_pool(config::routine_load_thread_pool_size, config::routine_load_thread_pool_size,

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -327,7 +327,7 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
         break;
     case TLoadSourceType::PULSAR:
         ctx->pulsar_info.reset(new PulsarLoadInfo(task.pulsar_load_info));
-        copy_from_ack_map(ctx->pulsar_info->ack_offset);
+        RoutineLoadTaskExecutor::copy_from_ack_map(ctx->pulsar_info->ack_offset);
         for (auto& kv : ctx->pulsar_info->ack_offset) {
             LOG(INFO) << "init pulsar_info ack_offset :" << kv.second << ", partition: " << kv.first;
         }
@@ -504,7 +504,7 @@ void RoutineLoadTaskExecutor::exec_task(std::shared_ptr<StreamLoadContext> ctx,
         break;
     }
     case TLoadSourceType::PULSAR: {
-        copy_to_ack_map(ctx->pulsar_info->ack_offset);
+        RoutineLoadTaskExecutor::copy_to_ack_map(ctx->pulsar_info->ack_offset);
         for (auto& kv : ctx->pulsar_info->ack_offset) {
             LOG(INFO) << "_last_ack_offset should be ack  :" << kv.second << ", partition: " << kv.first;
         }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -331,9 +331,9 @@ Status RoutineLoadTaskExecutor::submit_task(const TRoutineLoadTask& task) {
     case TLoadSourceType::PULSAR:
         ctx->pulsar_info.reset(new PulsarLoadInfo(task.pulsar_load_info));
         RoutineLoadTaskExecutor::copy_from_ack_map(ctx->pulsar_info->ack_offset);
-        for (auto& kv : ctx->pulsar_info->ack_offset) {
-            LOG(INFO) << "init pulsar_info ack_offset :" << kv.second << ", partition: " << kv.first;
-        }
+//        for (auto& kv : ctx->pulsar_info->ack_offset) {
+//            LOG(INFO) << "init pulsar_info ack_offset :" << kv.second << ", partition: " << kv.first;
+//        }
         break;
     default:
         LOG(WARNING) << "unknown load source type: " << task.type;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -581,11 +581,8 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
 void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
-        auto it = RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first);
-        if (it != RoutineLoadTaskExecutor::_last_ack_offset.end()) {
-            delete it->second;
-        }
-        RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = &kv.second;
+        RoutineLoadTaskExecutor::_last_ack_offset.erase(kv.first);
+        RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = std::make_unique<pulsar::MessageId>(kv.second);
     }
 }
 

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -581,6 +581,10 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
 void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
+        if (RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first) !=
+                RoutineLoadTaskExecutor::_last_ack_offset.end()) {
+            delete RoutineLoadTaskExecutor::_last_ack_offset[kv.first]; // 如果不为空，则释放资源
+        }
         RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }
 }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -584,7 +584,7 @@ static void copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
 
 static void copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
-    if (!_last_ack_offset.empty()) {
+    if (!RoutineLoadTaskExecutor::_last_ack_offset.empty()) {
         map = RoutineLoadTaskExecutor::_last_ack_offset;
     }
 }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -576,16 +576,16 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
 }
 
 static void copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
-    std::lock_guard<std::mutex> lock(_ack_mutex);
+    std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
-        _last_ack_offset[kv.first] = kv.second;
+        RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }
 }
 
 static void copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
-    std::lock_guard<std::mutex> lock(_ack_mutex);
+    std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     if (!_last_ack_offset.empty()) {
-        map = _last_ack_offset;
+        map = RoutineLoadTaskExecutor::_last_ack_offset;
     }
 }
 

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -62,7 +62,7 @@ using namespace ErrorCode;
 
 DEFINE_GAUGE_METRIC_PROTOTYPE_2ARG(routine_load_task_count, MetricUnit::NOUNIT);
 
-std::map<std::string, pulsar::MessageId> RoutineLoadTaskExecutor::_last_ack_offset;
+std::map<std::string, pulsar::MessageId*> RoutineLoadTaskExecutor::_last_ack_offset;
 std::mutex RoutineLoadTaskExecutor::_ack_mutex;
 
 RoutineLoadTaskExecutor::RoutineLoadTaskExecutor(ExecEnv* exec_env)
@@ -583,17 +583,18 @@ void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::Mess
     for (auto& kv : map) {
         auto it = RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first);
         if (it != RoutineLoadTaskExecutor::_last_ack_offset.end()) {
-            delete it->second; // 如果不为空，则释放资源
-            RoutineLoadTaskExecutor::_last_ack_offset.erase(it);
+            delete it->second;
         }
-        RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
+        RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = &kv.second;
     }
 }
 
 void RoutineLoadTaskExecutor::copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     if (!RoutineLoadTaskExecutor::_last_ack_offset.empty()) {
-        map = RoutineLoadTaskExecutor::_last_ack_offset;
+        for (auto& kv : RoutineLoadTaskExecutor::_last_ack_offset) {
+            map[kv.first] = *kv.second;
+        }
     }
 }
 

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -576,14 +576,14 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
 }
 
 static void copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
-    std::lock_guard<std::mutex> lock(ack_mutex);
+    std::lock_guard<std::mutex> lock(_ack_mutex);
     for (auto& kv : map) {
         _last_ack_offset[kv.first] = kv.second;
     }
 }
 
 static void copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map) {
-    std::lock_guard<std::mutex> lock(ack_mutex);
+    std::lock_guard<std::mutex> lock(_ack_mutex);
     if (!_last_ack_offset.empty()) {
         map = _last_ack_offset;
     }

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -581,10 +581,10 @@ Status RoutineLoadTaskExecutor::_execute_plan_for_test(std::shared_ptr<StreamLoa
 void RoutineLoadTaskExecutor::copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map) {
     std::lock_guard<std::mutex> lock(RoutineLoadTaskExecutor::_ack_mutex);
     for (auto& kv : map) {
-        if (RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first) !=
-                RoutineLoadTaskExecutor::_last_ack_offset.end()) {
-            pulsar::Message* msg = &RoutineLoadTaskExecutor::_last_ack_offset[kv.first];
-            delete msg; // 如果不为空，则释放资源
+        auto it = RoutineLoadTaskExecutor::_last_ack_offset.find(kv.first);
+        if (it != RoutineLoadTaskExecutor::_last_ack_offset.end()) {
+            delete it->second; // 如果不为空，则释放资源
+            RoutineLoadTaskExecutor::_last_ack_offset.erase(it);
         }
         RoutineLoadTaskExecutor::_last_ack_offset[kv.first] = kv.second;
     }

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -87,7 +87,7 @@ private:
                         std::shared_ptr<StreamLoadContext> ctx);
 
 public:
-    static std::map<std::string, pulsar::MessageId> _last_ack_offset;
+    static std::map<std::string, pulsar::MessageId*> _last_ack_offset;
     static std::mutex _ack_mutex;
 
 private:

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -68,6 +68,9 @@ public:
 
    Status get_pulsar_partition_backlog(const PPulsarBacklogProxyRequest& request, std::vector<int64_t>* backlog_num);
 
+   static void copy_to_ack_map(std::map<std::string, pulsar::MessageId> &map);
+
+   static void copy_from_ack_map(std::map<std::string, pulsar::MessageId> &map);
 
 private:
     // execute the task
@@ -92,7 +95,8 @@ private:
     // task id -> load context
     std::unordered_map<UniqueId, std::shared_ptr<StreamLoadContext>> _task_map;
 
-    std::map<std::string, pulsar::MessageId> _last_ack_offset;
+    static std::map<std::string, pulsar::MessageId> _last_ack_offset;
+    static std::mutex ack_mutex;
 };
 
 } // namespace doris

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -63,6 +63,11 @@ public:
     Status get_kafka_latest_offsets_for_partitions(const PKafkaMetaProxyRequest& request,
                                                    std::vector<PIntegerPair>* partition_offsets);
 
+   Status get_pulsar_partition_meta(const PPulsarMetaProxyRequest& request, std::vector<std::string>* partitions);
+
+   Status get_pulsar_partition_backlog(const PPulsarBacklogProxyRequest& request, std::vector<int64_t>* backlog_num);
+
+
 private:
     // execute the task
     void exec_task(std::shared_ptr<StreamLoadContext> ctx, DataConsumerPool* pool,
@@ -85,6 +90,8 @@ private:
     std::mutex _lock;
     // task id -> load context
     std::unordered_map<UniqueId, std::shared_ptr<StreamLoadContext>> _task_map;
+
+    std::map<std::string, pulsar::MessageId> _last_ack_offset;
 };
 
 } // namespace doris

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -87,7 +87,7 @@ private:
                         std::shared_ptr<StreamLoadContext> ctx);
 
 public:
-    static std::map<std::string, pulsar::MessageId*> _last_ack_offset;
+    static std::map<std::string, std::unique_ptr<pulsar::MessageId>> _last_ack_offset;
     static std::mutex _ack_mutex;
 
 private:

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -86,6 +86,10 @@ private:
     Status _prepare_ctx(const PKafkaMetaProxyRequest& request,
                         std::shared_ptr<StreamLoadContext> ctx);
 
+public:
+    static std::map<std::string, pulsar::MessageId> _last_ack_offset;
+    static std::mutex _ack_mutex;
+
 private:
     ExecEnv* _exec_env;
     PriorityThreadPool _thread_pool;
@@ -94,9 +98,6 @@ private:
     std::mutex _lock;
     // task id -> load context
     std::unordered_map<UniqueId, std::shared_ptr<StreamLoadContext>> _task_map;
-
-    static std::map<std::string, pulsar::MessageId> _last_ack_offset;
-    static std::mutex ack_mutex;
 };
 
 } // namespace doris

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -29,6 +29,7 @@
 #include "runtime/routine_load/data_consumer_pool.h"
 #include "util/uid_util.h"
 #include "util/work_thread_pool.hpp"
+#include "pulsar/Client.h"
 
 namespace doris {
 

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -334,6 +334,25 @@ std::string StreamLoadContext::brief(bool detail) const {
                 }
             }
             break;
+        case TLoadSourceType::PULSAR:
+            if (pulsar_info != nullptr) {
+                ss << ", load type: pulsar routine load"
+                   << ", source_url: " << pulsar_info->service_url << ", topic: " << pulsar_info->topic
+                   << ", subscription" << pulsar_info->subscription << ", partitions: [";
+                for (auto& partition : pulsar_info->partitions) {
+                    ss << partition << ",";
+                }
+                ss << "], initial positions: [";
+                for (const auto& [key, value] : pulsar_info->initial_positions) {
+                    ss << key << ":" << value << ",";
+                }
+                ss << "], properties: [";
+                for (auto& propertie : pulsar_info->properties) {
+                    ss << propertie.first << ": " << propertie.second << ",";
+                }
+                ss << "].";
+            }
+            break;
         default:
             break;
         }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -118,6 +118,9 @@ Status StreamLoadExecutor::execute_plan_fragment(std::shared_ptr<StreamLoadConte
                         case TLoadSourceType::KAFKA:
                             ctx->kafka_info->reset_offset();
                             break;
+                        case TLoadSourceType::PULSAR:
+                            ctx->pulsar_info->clear_backlog();
+                            break;
                         default:
                             break;
                         }
@@ -489,6 +492,20 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
 
         rl_attach.kafkaRLTaskProgress = kafka_progress;
         rl_attach.__isset.kafkaRLTaskProgress = true;
+        if (!ctx->error_url.empty()) {
+            rl_attach.__set_errorLogUrl(ctx->error_url);
+        }
+        return true;
+    }
+    case TLoadSourceType::PULSAR: {
+        TRLTaskTxnCommitAttachment& rl_attach = attach->rlTaskTxnCommitAttachment;
+        rl_attach.loadSourceType = TLoadSourceType::PULSAR;
+
+        TPulsarRLTaskProgress pulsar_progress;
+        pulsar_progress.partitionBacklogNum = ctx->pulsar_info->partition_backlog;
+
+        rl_attach.pulsarRLTaskProgress = pulsar_progress;
+        rl_attach.__isset.pulsarRLTaskProgress = true;
         if (!ctx->error_url.empty()) {
             rl_attach.__set_errorLogUrl(ctx->error_url);
         }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -790,6 +790,86 @@ void PInternalServiceImpl::get_info(google::protobuf::RpcController* controller,
     }
 }
 
+void PInternalServiceImpl::get_pulsar_info(google::protobuf::RpcController* controller,
+                                                  const PPulsarProxyRequest* request, PPulsarProxyResult* response,
+                                                  google::protobuf::Closure* done) {
+    int timeout_ms =
+            request->has_timeout() ? request->timeout() * 1000 : config::routine_load_pulsar_timeout_second * 1000;
+
+    auto task = [this, request, response, done, timeout_ms]() {
+        this->_get_pulsar_info_impl(request, response, done, timeout_ms);
+    };
+
+    auto st = _exec_env->send_batch_thread_pool()->submit_func(std::move(task));
+    if (!st.ok()) {
+        LOG(WARNING) << "get pulsar info: " << st << " ,timeout: " << timeout_ms
+                     << ", thread pool size: " << _exec_env->send_batch_thread_pool()->num_threads();
+        brpc::ClosureGuard closure_guard(done);
+        Status::Error<ErrorCode::SERVICE_UNAVAILABLE>(fmt::format("too busy to get pulsar info, please check the pulsar status, "
+                                               "timeout ms: {}",
+                                               timeout_ms))
+                .to_protobuf(response->mutable_status());
+    }
+}
+
+void PInternalServiceImpl::_get_pulsar_info_impl(const PPulsarProxyRequest* request,
+                                                        PPulsarProxyResult* response, google::protobuf::Closure* done,
+                                                        int timeout_ms) {
+    brpc::ClosureGuard closure_guard(done);
+
+    if (timeout_ms <= 0) {
+        Status::TimedOut("get pulsar info timeout").to_protobuf(response->mutable_status());
+        return;
+    }
+
+    if (request->has_pulsar_meta_request()) {
+        std::vector<std::string> partitions;
+        Status st = _exec_env->routine_load_task_executor()->get_pulsar_partition_meta(request->pulsar_meta_request(),
+                                                                                       &partitions);
+        if (st.ok()) {
+            PPulsarMetaProxyResult* pulsar_result = response->mutable_pulsar_meta_result();
+            for (const std::string& p : partitions) {
+                pulsar_result->add_partitions(p);
+            }
+        }
+        st.to_protobuf(response->mutable_status());
+        return;
+    }
+    if (request->has_pulsar_backlog_request()) {
+        std::vector<int64_t> backlog_nums;
+        Status st = _exec_env->routine_load_task_executor()->get_pulsar_partition_backlog(
+                request->pulsar_backlog_request(), &backlog_nums);
+        if (st.ok()) {
+            auto result = response->mutable_pulsar_backlog_result();
+            for (int i = 0; i < backlog_nums.size(); i++) {
+                result->add_partitions(request->pulsar_backlog_request().partitions(i));
+                result->add_backlog_nums(backlog_nums[i]);
+            }
+        }
+        st.to_protobuf(response->mutable_status());
+        return;
+    }
+    if (request->has_pulsar_backlog_batch_request()) {
+        for (const auto& backlog_req : request->pulsar_backlog_batch_request().requests()) {
+            std::vector<int64_t> backlog_nums;
+            Status st =
+                    _exec_env->routine_load_task_executor()->get_pulsar_partition_backlog(backlog_req, &backlog_nums);
+            auto backlog_result = response->mutable_pulsar_backlog_batch_result()->add_results();
+            if (st.ok()) {
+                for (int i = 0; i < backlog_nums.size(); i++) {
+                    backlog_result->add_partitions(backlog_req.partitions(i));
+                    backlog_result->add_backlog_nums(backlog_nums[i]);
+                }
+            } else {
+                response->clear_pulsar_backlog_batch_result();
+                st.to_protobuf(response->mutable_status());
+                return;
+            }
+        }
+    }
+    Status::OK().to_protobuf(response->mutable_status());
+}
+
 void PInternalServiceImpl::update_cache(google::protobuf::RpcController* controller,
                                         const PUpdateCacheRequest* request,
                                         PCacheResponse* response, google::protobuf::Closure* done) {

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -104,6 +104,12 @@ public:
     void get_info(google::protobuf::RpcController* controller, const PProxyRequest* request,
                   PProxyResult* response, google::protobuf::Closure* done) override;
 
+    void get_pulsar_info(google::protobuf::RpcController* controller, const PPulsarProxyRequest* request,
+                             PPulsarProxyResult* response, google::protobuf::Closure* done) override;
+
+    void _get_pulsar_info_impl(const PPulsarProxyRequest* request, PPulsarProxyResult* response,
+                                google::protobuf::Closure* done, int timeout_ms);
+
     void update_cache(google::protobuf::RpcController* controller,
                       const PUpdateCacheRequest* request, PCacheResponse* response,
                       google::protobuf::Closure* done) override;

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
@@ -189,7 +189,7 @@ public class AlterRoutineLoadStmt extends DdlStmt {
             long maxBatchSizeBytes = Util.getLongPropertyOrDefault(
                     jobProperties.get(CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY),
                     -1, CreateRoutineLoadStmt.MAX_BATCH_SIZE_PRED,
-                    CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 1GB");
+                    CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 2GB");
             analyzedJobProperties.put(CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY,
                     String.valueOf(maxBatchSizeBytes));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/AlterRoutineLoadStmt.java
@@ -189,7 +189,7 @@ public class AlterRoutineLoadStmt extends DdlStmt {
             long maxBatchSizeBytes = Util.getLongPropertyOrDefault(
                     jobProperties.get(CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY),
                     -1, CreateRoutineLoadStmt.MAX_BATCH_SIZE_PRED,
-                    CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 2GB");
+                    CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 3GB");
             analyzedJobProperties.put(CreateRoutineLoadStmt.MAX_BATCH_SIZE_PROPERTY,
                     String.valueOf(maxBatchSizeBytes));
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -187,7 +187,8 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final Predicate<Long> MAX_ERROR_NUMBER_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> MAX_BATCH_INTERVAL_PRED = (v) -> v >= 1 && v <= 60;
     public static final Predicate<Long> MAX_BATCH_ROWS_PRED = (v) -> v >= 200000;
-    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 3L*1024*1024*1024;
+    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024
+            && v <= 3L * 1024 * 1024 * 1024;
     public static final Predicate<Long> EXEC_MEM_LIMIT_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> SEND_BATCH_PARALLELISM_PRED = (v) -> v > 0L;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -457,7 +457,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
         maxBatchSizeBytes = Util.getLongPropertyOrDefault(jobProperties.get(MAX_BATCH_SIZE_PROPERTY),
                 RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE, MAX_BATCH_SIZE_PRED,
-                MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 2GB");
+                MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 3GB");
 
         strictMode = Util.getBooleanPropertyOrDefault(jobProperties.get(LoadStmt.STRICT_MODE),
                 RoutineLoadJob.DEFAULT_STRICT_MODE,

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -187,7 +187,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final Predicate<Long> MAX_ERROR_NUMBER_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> MAX_BATCH_INTERVAL_PRED = (v) -> v >= 1 && v <= 60;
     public static final Predicate<Long> MAX_BATCH_ROWS_PRED = (v) -> v >= 200000;
-    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 2 * 1024 * 1024 * 1024;
+    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 3096 * 1024 * 1024;
     public static final Predicate<Long> EXEC_MEM_LIMIT_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> SEND_BATCH_PARALLELISM_PRED = (v) -> v > 0L;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -187,7 +187,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final Predicate<Long> MAX_ERROR_NUMBER_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> MAX_BATCH_INTERVAL_PRED = (v) -> v >= 1 && v <= 60;
     public static final Predicate<Long> MAX_BATCH_ROWS_PRED = (v) -> v >= 200000;
-    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 3096 * 1024 * 1024;
+    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 3L*1024*1024*1024;
     public static final Predicate<Long> EXEC_MEM_LIMIT_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> SEND_BATCH_PARALLELISM_PRED = (v) -> v > 0L;
 

--- a/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/analysis/CreateRoutineLoadStmt.java
@@ -187,7 +187,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
     public static final Predicate<Long> MAX_ERROR_NUMBER_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> MAX_BATCH_INTERVAL_PRED = (v) -> v >= 1 && v <= 60;
     public static final Predicate<Long> MAX_BATCH_ROWS_PRED = (v) -> v >= 200000;
-    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 1024 * 1024 * 1024;
+    public static final Predicate<Long> MAX_BATCH_SIZE_PRED = (v) -> v >= 100 * 1024 * 1024 && v <= 2 * 1024 * 1024 * 1024;
     public static final Predicate<Long> EXEC_MEM_LIMIT_PRED = (v) -> v >= 0L;
     public static final Predicate<Long> SEND_BATCH_PARALLELISM_PRED = (v) -> v > 0L;
 
@@ -457,7 +457,7 @@ public class CreateRoutineLoadStmt extends DdlStmt {
 
         maxBatchSizeBytes = Util.getLongPropertyOrDefault(jobProperties.get(MAX_BATCH_SIZE_PROPERTY),
                 RoutineLoadJob.DEFAULT_MAX_BATCH_SIZE, MAX_BATCH_SIZE_PRED,
-                MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 1GB");
+                MAX_BATCH_SIZE_PROPERTY + " should between 100MB and 2GB");
 
         strictMode = Util.getBooleanPropertyOrDefault(jobProperties.get(LoadStmt.STRICT_MODE),
                 RoutineLoadJob.DEFAULT_STRICT_MODE,

--- a/fe/fe-core/src/main/java/org/apache/doris/common/util/PulsarUtil.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/common/util/PulsarUtil.java
@@ -1,0 +1,181 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.common.util;
+
+import org.apache.doris.catalog.Env;
+import org.apache.doris.common.LoadException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.proto.InternalService;
+import org.apache.doris.rpc.BackendServiceProxy;
+import org.apache.doris.system.Backend;
+import org.apache.doris.thrift.TNetworkAddress;
+import org.apache.doris.thrift.TStatusCode;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class PulsarUtil {
+    private static final Logger LOG = LogManager.getLogger(PulsarUtil.class);
+
+    private static final ProxyAPI PROXY_API = new ProxyAPI();
+
+    public static List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                      ImmutableMap<String, String> properties) throws UserException {
+        return PROXY_API.getAllPulsarPartitions(serviceUrl, topic, subscription, properties);
+    }
+
+    public static Map<String, Long> getBacklogNums(String serviceUrl, String topic, String subscription,
+                                                   ImmutableMap<String, String> properties,
+                                                   List<String> partitions) throws UserException {
+        return PROXY_API.getBacklogNums(serviceUrl, topic, subscription, properties, partitions);
+    }
+
+    public static List<InternalService.PPulsarBacklogProxyResult> getBatchBacklogNums(
+            List<InternalService.PPulsarBacklogProxyRequest> requests) throws UserException {
+        return PROXY_API.getBatchBacklogNums(requests);
+    }
+
+    public static InternalService.PPulsarLoadInfo genPPulsarLoadInfo(String serviceUrl,
+                                                                     String topic, String subscription,
+                                                                     ImmutableMap<String, String> properties) {
+        InternalService.PPulsarLoadInfo pulsarLoadInfo = InternalService.PPulsarLoadInfo.newBuilder()
+                .setServiceUrl(serviceUrl)
+                .setTopic(topic)
+                .setSubscription(subscription)
+                .addAllProperties(
+                properties.entrySet().stream().map(
+                    e -> InternalService.PStringPair.newBuilder()
+                        .setKey(e.getKey())
+                        .setVal(e.getValue())
+                        .build()
+                ).collect(Collectors.toList())
+            ).build();
+        return pulsarLoadInfo;
+    }
+
+    static class ProxyAPI {
+        public List<String> getAllPulsarPartitions(String serviceUrl, String topic, String subscription,
+                                                   ImmutableMap<String, String> convertedCustomProperties)
+                throws UserException {
+            // create request
+            InternalService.PPulsarMetaProxyRequest metaRequest = InternalService.PPulsarMetaProxyRequest.newBuilder()
+                    .setPulsarInfo(genPPulsarLoadInfo(serviceUrl, topic, subscription, convertedCustomProperties))
+                    .build();
+            InternalService.PPulsarProxyRequest request = InternalService.PPulsarProxyRequest.newBuilder()
+                    .setPulsarMetaRequest(metaRequest).build();
+
+            InternalService.PPulsarProxyResult result = sendProxyRequest(request);
+            return result.getPulsarMetaResult().getPartitionsList();
+        }
+
+        public Map<String, Long> getBacklogNums(String serviceUrl, String topic, String subscription,
+                                                ImmutableMap<String, String> properties, List<String> partitions)
+                throws UserException {
+            // create request
+            InternalService.PPulsarBacklogProxyRequest.Builder backlogRequest =
+                    InternalService.PPulsarBacklogProxyRequest.newBuilder()
+                    .setPulsarInfo(genPPulsarLoadInfo(serviceUrl, topic, subscription, properties));
+            for (String partition : partitions) {
+                backlogRequest.addPartitions(partition);
+            }
+            InternalService.PPulsarProxyRequest request = InternalService.PPulsarProxyRequest.newBuilder()
+                    .setPulsarBacklogRequest(backlogRequest).build();
+
+            // send request
+            InternalService.PPulsarProxyResult result = sendProxyRequest(request);
+
+            // assembly result
+            Map<String, Long> partitionBacklogs = Maps.newHashMapWithExpectedSize(partitions.size());
+            List<Long> backlogs = result.getPulsarBacklogResult().getBacklogNumsList();
+            for (int i = 0; i < result.getPulsarBacklogResult().getPartitionsList().size(); i++) {
+                partitionBacklogs.put(result.getPulsarBacklogResult().getPartitionsList().get(i), backlogs.get(i));
+            }
+            return partitionBacklogs;
+        }
+
+        public List<InternalService.PPulsarBacklogProxyResult> getBatchBacklogNums(
+                List<InternalService.PPulsarBacklogProxyRequest> requests)
+                throws UserException {
+            // create request
+            InternalService.PPulsarBacklogBatchProxyRequest.Builder pPulsarBacklogBatchProxyRequest =
+                    InternalService.PPulsarBacklogBatchProxyRequest.newBuilder();
+            for (InternalService.PPulsarBacklogProxyRequest request : requests) {
+                pPulsarBacklogBatchProxyRequest.addRequests(request);
+            }
+            InternalService.PPulsarProxyRequest pProxyRequest = InternalService.PPulsarProxyRequest.newBuilder()
+                    .setPulsarBacklogBatchRequest(pPulsarBacklogBatchProxyRequest).build();
+
+            // send request
+            InternalService.PPulsarProxyResult result = sendProxyRequest(pProxyRequest);
+
+            return result.getPulsarBacklogBatchResult().getResultsList();
+        }
+
+        private InternalService.PPulsarProxyResult sendProxyRequest(
+                InternalService.PPulsarProxyRequest request) throws UserException {
+            TNetworkAddress address = new TNetworkAddress();
+            try {
+                // TODO: need to refactor after be split into cn + dn
+                List<Long> nodeIds = new ArrayList<>();
+                nodeIds = Env.getCurrentSystemInfo().getAllBackendIds(true);
+                if (nodeIds.isEmpty()) {
+                    throw new LoadException("Failed to send proxy request. No alive backends");
+                }
+
+                Collections.shuffle(nodeIds);
+
+                Backend be = Env.getCurrentSystemInfo().getBackend(nodeIds.get(0));
+                address = new TNetworkAddress(be.getHost(), be.getBrpcPort());
+
+                // get info
+                Future<InternalService.PPulsarProxyResult> future =
+                        BackendServiceProxy.getInstance().getPulsarInfo(address, request);
+                InternalService.PPulsarProxyResult result = future.get(10, TimeUnit.SECONDS);
+                TStatusCode code = TStatusCode.findByValue(result.getStatus().getStatusCode());
+                if (code != TStatusCode.OK) {
+                    LOG.warn("failed to send proxy request to "
+                            + address + " err " + result.getStatus().getErrorMsgsList());
+                    throw new UserException(
+                        "failed to send proxy request to " + address
+                            + " err " + result.getStatus().getErrorMsgsList());
+                } else {
+                    return result;
+                }
+            } catch (InterruptedException ie) {
+                LOG.warn("got interrupted exception when sending proxy request to " + address);
+                Thread.currentThread().interrupt();
+                throw new LoadException("got interrupted exception when sending proxy request to " + address);
+            } catch (Exception e) {
+                LOG.warn("failed to send proxy request to " + address + " err " + e.getMessage());
+                throw new LoadException("failed to send proxy request to " + address + " err " + e.getMessage());
+            }
+        }
+    }
+}
+

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/LoadDataSourceType.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/LoadDataSourceType.java
@@ -18,5 +18,6 @@
 package org.apache.doris.load.routineload;
 
 public enum LoadDataSourceType {
-    KAFKA
+    KAFKA,
+    PULSAR
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarProgress.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarProgress.java
@@ -1,0 +1,169 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.load.routineload;
+
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.thrift.TPulsarRLTaskProgress;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * this is description of pulsar routine load progress
+ * the data before position was already loaded in StarRocks
+ */
+// {"partitionToBacklogNum": {}}
+public class PulsarProgress extends RoutineLoadProgress {
+    private static final Logger LOG = LogManager.getLogger(PulsarProgress.class);
+
+    // (partition, backlog num)
+    @SerializedName("pbl")
+    private Map<String, Long> partitionToBacklogNum = Maps.newConcurrentMap();
+    // Initial positions will only be used at first schedule
+    private Map<String, Long> partitionToInitialPosition = Maps.newConcurrentMap();
+
+    public PulsarProgress() {
+        super(LoadDataSourceType.PULSAR);
+    }
+
+    public PulsarProgress(TPulsarRLTaskProgress tPulsarRLTaskProgress) {
+        super(LoadDataSourceType.PULSAR);
+        this.partitionToBacklogNum = tPulsarRLTaskProgress.getPartitionBacklogNum();
+    }
+
+    public Map<String, Long> getPartitionToInitialPosition(List<String> partitions) {
+        Map<String, Long> result = Maps.newHashMap();
+        for (Map.Entry<String, Long> entry : partitionToInitialPosition.entrySet()) {
+            for (String partition : partitions) {
+                if (entry.getKey().equals(partition)) {
+                    result.put(partition, entry.getValue());
+                }
+            }
+        }
+        return result;
+    }
+
+    public List<Long> getBacklogNums() {
+        return new ArrayList<Long>(partitionToBacklogNum.values());
+    }
+
+    public Long getInitialPosition(String partition) {
+        if (partitionToInitialPosition.containsKey(partition)) {
+            return partitionToInitialPosition.get(partition);
+        } else {
+            return -1L;
+        }
+    }
+
+    public void addPartitionToInitialPosition(Pair<String, Long> partitionToInitialPosition) {
+        this.partitionToInitialPosition.put(partitionToInitialPosition.first, partitionToInitialPosition.second);
+    }
+
+    public void modifyInitialPositions(List<Pair<String, Long>> partitionInitialPositions) {
+        for (Pair<String, Long> pair : partitionInitialPositions) {
+            this.partitionToInitialPosition.put(pair.first, pair.second);
+        }
+    }
+
+    public void unprotectUpdate(List<String> currentPartitions, Long defaultInitialPosition) {
+        partitionToInitialPosition.keySet().stream()
+            .filter(entry -> !currentPartitions.contains(entry))
+            .forEach(entry -> partitionToInitialPosition.remove(entry));
+
+        if (defaultInitialPosition != null) {
+            currentPartitions.stream()
+                .filter(entry -> !partitionToInitialPosition.containsKey(entry))
+                    .forEach(entry -> partitionToInitialPosition.put(entry, defaultInitialPosition));
+        }
+    }
+
+    private void getReadableProgress(Map<String, String> showPartitionIdToPosition) {
+        for (Map.Entry<String, Long> entry : partitionToBacklogNum.entrySet()) {
+            showPartitionIdToPosition.put(entry.getKey() + "(BacklogNum)", String.valueOf(entry.getValue()));
+        }
+    }
+
+    public Map<String, Long> getLag() {
+        return partitionToBacklogNum;
+    }
+
+    @Override
+    public String toString() {
+        Map<String, String> showPartitionToBacklogNum = Maps.newHashMap();
+        getReadableProgress(showPartitionToBacklogNum);
+        return "PulsarProgress [partitionToBacklogNum="
+            + Joiner.on("|").withKeyValueSeparator("_").join(showPartitionToBacklogNum) + "]";
+    }
+
+    @Override
+    public String toJsonString() {
+        Map<String, String> showPartitionToBacklogNum = Maps.newHashMap();
+        getReadableProgress(showPartitionToBacklogNum);
+        Gson gson = new Gson();
+        return gson.toJson(showPartitionToBacklogNum);
+    }
+
+    @Override
+    public void update(RLTaskTxnCommitAttachment attachment) {
+        PulsarProgress newProgress = (PulsarProgress) attachment.getProgress();
+        for (Map.Entry<String, Long> entry : newProgress.partitionToBacklogNum.entrySet()) {
+            String partition = entry.getKey();
+            Long backlogNum = entry.getValue();
+            // Update progress
+            this.partitionToBacklogNum.put(partition, backlogNum);
+            // Remove initial position if exists
+            partitionToInitialPosition.remove(partition);
+        }
+        LOG.debug("update pulsar progress: {}, task: {}, job: {}",
+                newProgress.toJsonString(), DebugUtil.printId(attachment.getTaskId()), attachment.getJobId());
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+        out.writeInt(partitionToBacklogNum.size());
+        for (Map.Entry<String, Long> entry : partitionToBacklogNum.entrySet()) {
+            Text.writeString(out, entry.getKey());
+            out.writeLong((Long) entry.getValue());
+        }
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        int size = in.readInt();
+        partitionToBacklogNum = new HashMap<>();
+        for (int i = 0; i < size; i++) {
+            partitionToBacklogNum.put(Text.readString(in), in.readLong());
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarRoutineLoadJob.java
@@ -680,6 +680,6 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
 
     @Override
     public double getMaxFilterRatio() {
-        return maxFilterRatio;
+        return 1.0;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarRoutineLoadJob.java
@@ -1,0 +1,685 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.load.routineload;
+
+import org.apache.doris.analysis.AlterRoutineLoadStmt;
+import org.apache.doris.analysis.CreateRoutineLoadStmt;
+import org.apache.doris.analysis.UserIdentity;
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.OlapTable;
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Config;
+import org.apache.doris.common.DdlException;
+import org.apache.doris.common.ErrorCode;
+import org.apache.doris.common.ErrorReport;
+import org.apache.doris.common.InternalErrorCode;
+import org.apache.doris.common.LoadException;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.io.Text;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.common.util.LogBuilder;
+import org.apache.doris.common.util.LogKey;
+import org.apache.doris.common.util.PulsarUtil;
+import org.apache.doris.common.util.SmallFileMgr;
+import org.apache.doris.common.util.SmallFileMgr.SmallFile;
+import org.apache.doris.load.routineload.pulsar.PulsarConfiguration;
+import org.apache.doris.load.routineload.pulsar.PulsarDataSourceProperties;
+import org.apache.doris.persist.AlterRoutineLoadJobOperationLog;
+import org.apache.doris.thrift.TFileCompressType;
+import org.apache.doris.transaction.TransactionState;
+import org.apache.doris.transaction.TransactionStatus;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * PulsarRoutineLoadJob is a kind of RoutineLoadJob which fetch data from pulsar.
+ * The progress which is super class property is seems like "{"partition1": backlognum1, "partition2": backlognum2}"
+ */
+public class PulsarRoutineLoadJob extends RoutineLoadJob {
+    private static final Logger LOG = LogManager.getLogger(PulsarRoutineLoadJob.class);
+
+    public static final String PULSAR_FILE_CATALOG = "pulsar";
+
+    @SerializedName("svu")
+    private String serviceUrl;
+    @SerializedName("tpc")
+    private String topic;
+    @SerializedName("sbs")
+    private String subscription;
+    // optional, user want to load partitions.
+    @SerializedName("cpp")
+    private List<String> customPulsarPartitions = Lists.newArrayList();
+    // current pulsar partitions is the actually partition which will be fetched
+    private List<String> currentPulsarPartitions = Lists.newArrayList();
+    // pulsar properties, property prefix will be mapped to pulsar custom parameters,
+    // which can be extended in the future
+    @SerializedName("cpt")
+    private Map<String, String> customProperties = Maps.newHashMap();
+    private Map<String, String> convertedCustomProperties = Maps.newHashMap();
+
+    public static final String POSITION_EARLIEST = "POSITION_EARLIEST"; // 1
+    public static final String POSITION_LATEST = "POSITION_LATEST"; // 0
+    public static final long POSITION_LATEST_VAL = 0;
+    public static final long POSITION_EARLIEST_VAL = 1;
+
+    private Long defaultInitialPosition = null;
+
+    public PulsarRoutineLoadJob() {
+        // for serialization, id is dummy
+        super(-1, LoadDataSourceType.PULSAR);
+    }
+
+    public PulsarRoutineLoadJob(Long id, String name, String clusterName, long dbId, long tableId,
+                                String serviceUrl, String topic, String subscription,
+                                UserIdentity userIdentity) {
+        super(id, name, clusterName, dbId, tableId, LoadDataSourceType.PULSAR, userIdentity);
+        this.serviceUrl = serviceUrl;
+        this.topic = topic;
+        this.subscription = subscription;
+        this.progress = new PulsarProgress();
+    }
+
+    public PulsarRoutineLoadJob(Long id, String name, String clusterName, long dbId,
+                                String serviceUrl, String topic, String subscription,
+                                UserIdentity userIdentity, boolean isMultiTable) {
+        super(id, name, clusterName, dbId, LoadDataSourceType.PULSAR, userIdentity);
+        this.serviceUrl = serviceUrl;
+        this.topic = topic;
+        this.subscription = subscription;
+        this.progress = new PulsarProgress();
+        setMultiTable(isMultiTable);
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    public String getSubscription() {
+        return subscription;
+    }
+
+    public Map<String, String> getConvertedCustomProperties() {
+        return convertedCustomProperties;
+    }
+
+    @Override
+    public void prepare() throws UserException {
+        super.prepare();
+        // should reset converted properties each time the job being prepared.
+        // because the file info can be changed anytime.
+        convertCustomProperties(true);
+    }
+
+    public synchronized void convertCustomProperties(boolean rebuild) throws DdlException {
+        if (customProperties.isEmpty()) {
+            return;
+        }
+
+        if (!rebuild && !convertedCustomProperties.isEmpty()) {
+            return;
+        }
+
+        if (rebuild) {
+            convertedCustomProperties.clear();
+        }
+
+        SmallFileMgr smallFileMgr = Env.getCurrentEnv().getSmallFileMgr();
+        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
+            if (entry.getValue().startsWith("FILE:")) {
+                // convert FILE:file_name -> FILE:file_id:md5
+                String file = entry.getValue().substring(entry.getValue().indexOf(":") + 1);
+                SmallFile smallFile = smallFileMgr.getSmallFile(dbId, PULSAR_FILE_CATALOG, file, true);
+                convertedCustomProperties.put(entry.getKey(), "FILE:" + smallFile.id + ":" + smallFile.md5);
+            } else {
+                convertedCustomProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        if (convertedCustomProperties.containsKey(PulsarConfiguration.PULSAR_DEFAULT_INITIAL_POSITION.getName())) {
+            try {
+                this.defaultInitialPosition = PulsarDataSourceProperties.getPulsarPosition(
+                    convertedCustomProperties.remove(PulsarConfiguration.PULSAR_DEFAULT_INITIAL_POSITION.getName()));
+            } catch (AnalysisException e) {
+                throw new DdlException(e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void divideRoutineLoadJob(int currentConcurrentTaskNum) throws UserException {
+        List<RoutineLoadTaskInfo> result = new ArrayList<>();
+        writeLock();
+        try {
+            if (state == JobState.NEED_SCHEDULE) {
+                // divide pulsarPartitions into tasks
+                for (int i = 0; i < currentConcurrentTaskNum; i++) {
+                    List<String> partitions = Lists.newArrayList();
+                    Map<String, Long> initialPositions = Maps.newHashMap();
+                    for (int j = 0; j < currentPulsarPartitions.size(); j++) {
+                        if (j % currentConcurrentTaskNum == i) {
+                            String partition = currentPulsarPartitions.get(j);
+                            partitions.add(partition);
+                            // initial position was set, need to be added into PulsarTaskInfo
+                            Long initialPosition = ((PulsarProgress) progress).getInitialPosition(partition);
+                            if (initialPosition != -1L) {
+                                initialPositions.put(partition, initialPosition);
+                            }
+                        }
+                    }
+                    PulsarTaskInfo pulsarTaskInfo = new PulsarTaskInfo(UUID.randomUUID(), id,
+                            clusterName, partitions,
+                            initialPositions, maxBatchIntervalS * 2 * 1000, isMultiTable());
+                    LOG.debug("pulsar routine load task created: " + pulsarTaskInfo);
+                    routineLoadTaskInfoList.add(pulsarTaskInfo);
+                    result.add(pulsarTaskInfo);
+                }
+                // change job state to running
+                if (result.size() != 0) {
+                    unprotectUpdateState(JobState.RUNNING, null, false);
+                }
+            } else {
+                LOG.debug("Ignore to divide routine load job while job state {}", state);
+            }
+            // save task into queue of needScheduleTasks
+            Env.getCurrentEnv().getRoutineLoadTaskScheduler().addTasksInQueue(result);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @Override
+    public int calculateCurrentConcurrentTaskNum() {
+        int partitionNum = currentPulsarPartitions.size();
+        if (desireTaskConcurrentNum == 0) {
+            desireTaskConcurrentNum = Config.max_routine_load_task_concurrent_num;
+        }
+
+        LOG.debug("current concurrent task number is min"
+                + "(partition num: {}, desire task concurrent num: {}, config: {})",
+                partitionNum, desireTaskConcurrentNum, Config.max_routine_load_task_concurrent_num);
+        currentTaskConcurrentNum = Math.min(partitionNum, Math.min(desireTaskConcurrentNum,
+            Config.max_routine_load_task_concurrent_num));
+        return currentTaskConcurrentNum;
+    }
+
+    // Through the transaction status and attachment information, to determine whether the progress needs to be updated.
+    @Override
+    protected boolean checkCommitInfo(RLTaskTxnCommitAttachment rlTaskTxnCommitAttachment,
+                                      TransactionState txnState,
+                                      TransactionState.TxnStatusChangeReason txnStatusChangeReason) {
+        if (txnState.getTransactionStatus() == TransactionStatus.COMMITTED) {
+            // For committed txn, update the progress.
+            return true;
+        }
+
+        // For compatible reason, the default behavior of empty load is still returning "all partitions
+        // have no load data" and abort transaction.
+        // In this situation, we also need update commit info.
+        if (txnStatusChangeReason != null
+                && txnStatusChangeReason == TransactionState.TxnStatusChangeReason.NO_PARTITIONS) {
+            // Because the max_filter_ratio of routine load task is always 1.
+            // Therefore, under normal circumstances,
+            // routine load task will not return the error "too many filtered rows".
+            // If no data is imported, the error "all partitions have no load data" may only be returned.
+            // In this case, the status of the transaction is ABORTED,
+            // but we still need to update the position to skip these error lines.
+            Preconditions.checkState(txnState.getTransactionStatus() == TransactionStatus.ABORTED,
+                    txnState.getTransactionStatus());
+            return true;
+        }
+
+        // Running here, the status of the transaction should be ABORTED,
+        // and it is caused by other errors. In this case, we should not update the position.
+        LOG.debug("no need to update the progress of pulsar routine load. txn status: {}, "
+                + "txnStatusChangeReason: {}, task: {}, job: {}",
+                txnState.getTransactionStatus(), txnStatusChangeReason,
+                DebugUtil.printId(rlTaskTxnCommitAttachment.getTaskId()), id);
+        return false;
+    }
+
+    @Override
+    protected void updateProgress(RLTaskTxnCommitAttachment attachment) throws UserException {
+        super.updateProgress(attachment);
+        this.progress.update(attachment);
+    }
+
+    @Override
+    protected void replayUpdateProgress(RLTaskTxnCommitAttachment attachment) {
+        super.replayUpdateProgress(attachment);
+        this.progress.update(attachment);
+    }
+
+    @Override
+    protected RoutineLoadTaskInfo unprotectRenewTask(RoutineLoadTaskInfo routineLoadTaskInfo) {
+        PulsarTaskInfo oldPulsarTaskInfo = (PulsarTaskInfo) routineLoadTaskInfo;
+        // add new task
+        PulsarTaskInfo pulsarTaskInfo = new PulsarTaskInfo(oldPulsarTaskInfo,
+                ((PulsarProgress) progress).getPartitionToInitialPosition(oldPulsarTaskInfo.getPartitions()),
+                isMultiTable());
+        // remove old task
+        routineLoadTaskInfoList.remove(routineLoadTaskInfo);
+        // add new task
+        routineLoadTaskInfoList.add(pulsarTaskInfo);
+        LOG.debug("pulsar routine load task renewed: " + pulsarTaskInfo);
+        return pulsarTaskInfo;
+    }
+
+    @Override
+    protected void unprotectUpdateProgress() {
+        ((PulsarProgress) progress).unprotectUpdate(currentPulsarPartitions, defaultInitialPosition);
+    }
+
+    // if customPulsarPartition is not null, then return false immediately
+    // else if pulsar partitions of topic has been changed, return true.
+    // else return false
+    // update current pulsar partition at the same time
+    // current pulsar partitions = customPulsarPartitions == 0 ?
+    // all of partition of pulsar topic : customPulsarPartitions
+    @Override
+    protected boolean unprotectNeedReschedule() throws UserException {
+        // only running and need_schedule job need to be changed current pulsar partitions
+        if (this.state == JobState.RUNNING || this.state == JobState.NEED_SCHEDULE) {
+            if (customPulsarPartitions != null && customPulsarPartitions.size() != 0) {
+                currentPulsarPartitions = customPulsarPartitions;
+                return false;
+            } else {
+                List<String> newCurrentPulsarPartition;
+                try {
+                    newCurrentPulsarPartition = getAllPulsarPartitions();
+                } catch (Exception e) {
+                    String msg = "Job failed to fetch all current partition with error [" + e.getMessage() + "]";
+                    LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                            .add("error_msg", msg)
+                            .build(), e);
+                    if (this.state == JobState.NEED_SCHEDULE) {
+                        unprotectUpdateState(JobState.PAUSED,
+                            new ErrorReason(InternalErrorCode.PARTITIONS_ERR, msg),
+                                false /* not replay */);
+                    }
+                    return false;
+                }
+                if (currentPulsarPartitions.containsAll(newCurrentPulsarPartition)) {
+                    if (currentPulsarPartitions.size() > newCurrentPulsarPartition.size()) {
+                        unprotectUpdateCurrentPartitions(newCurrentPulsarPartition);
+                        return true;
+                    } else {
+                        return false;
+                    }
+                } else {
+                    unprotectUpdateCurrentPartitions(newCurrentPulsarPartition);
+                    return true;
+                }
+            }
+        } else if (this.state == JobState.PAUSED) {
+            boolean autoSchedule = ScheduleRule.isNeedAutoSchedule(this);
+            if (autoSchedule) {
+                LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, name)
+                        .add("current_state", this.state)
+                        .add("msg", "should be rescheduled")
+                        .build());
+            }
+            return autoSchedule;
+        } else {
+            return false;
+        }
+    }
+
+    protected void unprotectUpdateCurrentPartitions(List<String> newCurrentPartitions) {
+        currentPulsarPartitions = newCurrentPartitions;
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                    .add("current_pulsar_partitions", Joiner.on(",").join(currentPulsarPartitions))
+                    .add("msg", "current pulsar partitions has been change")
+                    .build());
+        }
+    }
+
+    @Override
+    protected String getStatistic() {
+        Map<String, Object> summary = this.jobStatistic.summary();
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        return gson.toJson(summary);
+    }
+
+    private List<String> getAllPulsarPartitions() throws UserException {
+        // Get custom properties like tokens
+        convertCustomProperties(false);
+        return PulsarUtil.getAllPulsarPartitions(serviceUrl, topic,
+            subscription, ImmutableMap.copyOf(convertedCustomProperties));
+    }
+
+    public static PulsarRoutineLoadJob fromCreateStmt(CreateRoutineLoadStmt stmt) throws UserException {
+        // check db and table
+        Database db = Env.getCurrentInternalCatalog().getDbOrDdlException(stmt.getDBName());
+        if (db == null) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, stmt.getDBName());
+        }
+
+        // init pulsar routine load job
+        long id = Env.getCurrentEnv().getNextId();
+        PulsarDataSourceProperties pulsarProperties = (PulsarDataSourceProperties) stmt.getDataSourceProperties();
+        PulsarRoutineLoadJob pulsarRoutineLoadJob;
+        if (pulsarProperties.isMultiTable()) {
+            pulsarRoutineLoadJob = new PulsarRoutineLoadJob(id, stmt.getName(), db.getClusterName(), db.getId(),
+                pulsarProperties.getPulsarServiceUrl(), pulsarProperties.getPulsarTopic(),
+                pulsarProperties.getPulsarSubscription(), stmt.getUserInfo(), true);
+        } else {
+            OlapTable olapTable = db.getOlapTableOrDdlException(stmt.getTableName());
+            checkMeta(olapTable, stmt.getRoutineLoadDesc());
+            long tableId = olapTable.getId();
+            pulsarRoutineLoadJob = new PulsarRoutineLoadJob(id, stmt.getName(), db.getClusterName(), db.getId(),
+                tableId, pulsarProperties.getPulsarServiceUrl(), pulsarProperties.getPulsarTopic(),
+                pulsarProperties.getPulsarSubscription(), stmt.getUserInfo());
+        }
+        pulsarRoutineLoadJob.setOptional(stmt);
+        pulsarRoutineLoadJob.checkCustomProperties();
+        pulsarRoutineLoadJob.checkCustomPartition();
+
+        return pulsarRoutineLoadJob;
+    }
+
+    private void checkCustomPartition() throws UserException {
+        if (customPulsarPartitions.isEmpty()) {
+            return;
+        }
+        List<String> allPulsarPartitions = getAllPulsarPartitions();
+        for (String customPartition : customPulsarPartitions) {
+            if (!allPulsarPartitions.contains(customPartition)) {
+                throw new LoadException("there is a custom pulsar partition " + customPartition
+                    + " which is invalid for topic " + topic);
+            }
+        }
+    }
+
+    private void checkCustomProperties() throws DdlException {
+        SmallFileMgr smallFileMgr = Env.getCurrentEnv().getSmallFileMgr();
+        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
+            if (entry.getValue().startsWith("FILE:")) {
+                String file = entry.getValue().substring(entry.getValue().indexOf(":") + 1);
+                // check file
+                if (!smallFileMgr.containsFile(dbId, PULSAR_FILE_CATALOG, file)) {
+                    throw new DdlException("File " + file + " does not exist in db "
+                        + dbId + " with globalStateMgr: " + PULSAR_FILE_CATALOG);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void setOptional(CreateRoutineLoadStmt stmt) throws UserException {
+        super.setOptional(stmt);
+        PulsarDataSourceProperties pulsarDataSourceProperties
+                = (PulsarDataSourceProperties) stmt.getDataSourceProperties();
+        if (CollectionUtils.isNotEmpty(pulsarDataSourceProperties.getPulsarPartitions())) {
+            setCustomPulsarPartitions(pulsarDataSourceProperties.getPulsarPartitions());
+        }
+
+        if (CollectionUtils.isNotEmpty(pulsarDataSourceProperties.getPulsarPartitionInitialPositions())) {
+            setPulsarPatitionInitialPositions(pulsarDataSourceProperties.getPulsarPartitionInitialPositions());
+        }
+
+        if (MapUtils.isNotEmpty(pulsarDataSourceProperties.getCustomPulsarProperties())) {
+            setCustomPulsarProperties(pulsarDataSourceProperties.getCustomPulsarProperties());
+        }
+    }
+
+    // this is an unprotected method which is called in the initialization function
+    private void setCustomPulsarPartitions(List<String> pulsarPartitions) {
+        this.customPulsarPartitions = pulsarPartitions;
+    }
+
+    private void setPulsarPatitionInitialPositions(List<Pair<String, Long>> patitionToInitialPositions) {
+        for (Pair<String, Long> entry : patitionToInitialPositions) {
+            ((PulsarProgress) progress).addPartitionToInitialPosition(entry);
+        }
+    }
+
+    private void setCustomPulsarProperties(Map<String, String> pulsarProperties) {
+        this.customProperties = pulsarProperties;
+    }
+
+    @Override
+    protected String dataSourcePropertiesJsonToString() {
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        dataSourceProperties.put("serviceUrl", serviceUrl);
+        dataSourceProperties.put("topic", topic);
+        dataSourceProperties.put("subscription", subscription);
+        List<String> sortedPartitions = Lists.newArrayList(currentPulsarPartitions);
+        Collections.sort(sortedPartitions);
+        dataSourceProperties.put("currentPulsarPartitions", Joiner.on(",").join(sortedPartitions));
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        return gson.toJson(dataSourceProperties);
+    }
+
+    @Override
+    protected String customPropertiesJsonToString() {
+        Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+        return gson.toJson(customProperties);
+    }
+
+    @Override
+    protected Map<String, String> getDataSourceProperties() {
+        Map<String, String> dataSourceProperties = Maps.newHashMap();
+        dataSourceProperties.put(PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName(), serviceUrl);
+        dataSourceProperties.put(PulsarConfiguration.PULSAR_TOPIC_PROPERTY.getName(), topic);
+        dataSourceProperties.put(PulsarConfiguration.PULSAR_SUBSCRIPTION_PROPERTY.getName(), subscription);
+        return dataSourceProperties;
+    }
+
+    @Override
+    protected Map<String, String> getCustomProperties() {
+        Map<String, String> ret = new HashMap<>();
+        customProperties.forEach((k, v) -> ret.put("property." + k, v));
+        return ret;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+        Text.writeString(out, serviceUrl);
+        Text.writeString(out, topic);
+        Text.writeString(out, subscription);
+
+        out.writeInt(customPulsarPartitions.size());
+        for (String partition : customPulsarPartitions) {
+            Text.writeString(out, partition);
+        }
+
+        out.writeInt(customProperties.size());
+        for (Map.Entry<String, String> property : customProperties.entrySet()) {
+            Text.writeString(out, "property." + property.getKey());
+            Text.writeString(out, property.getValue());
+        }
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        serviceUrl = Text.readString(in);
+        topic = Text.readString(in);
+        subscription = Text.readString(in);
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            customPulsarPartitions.add(Text.readString(in));
+        }
+
+        int count = in.readInt();
+        for (int i = 0; i < count; i++) {
+            String propertyKey = Text.readString(in);
+            String propertyValue = Text.readString(in);
+            if (propertyKey.startsWith("property.")) {
+                this.customProperties.put(propertyKey.substring(propertyKey.indexOf(".") + 1), propertyValue);
+            }
+        }
+    }
+
+    @Override
+    public void modifyProperties(AlterRoutineLoadStmt stmt) throws UserException {
+        Map<String, String> jobProperties = stmt.getAnalyzedJobProperties();
+        PulsarDataSourceProperties dataSourceProperties = (PulsarDataSourceProperties) stmt.getDataSourceProperties();
+
+        writeLock();
+        try {
+            if (getState() != JobState.PAUSED) {
+                throw new DdlException("Only supports modification of PAUSED jobs");
+            }
+
+            modifyPropertiesInternal(jobProperties, dataSourceProperties);
+
+            AlterRoutineLoadJobOperationLog log = new AlterRoutineLoadJobOperationLog(this.id,
+                    jobProperties, dataSourceProperties);
+            Env.getCurrentEnv().getEditLog().logAlterRoutineLoadJob(log);
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    @Override
+    public void replayModifyProperties(AlterRoutineLoadJobOperationLog log) {
+        try {
+            modifyPropertiesInternal(log.getJobProperties(),
+                    (PulsarDataSourceProperties) log.getDataSourceProperties());
+        } catch (DdlException e) {
+            // should not happen
+            LOG.error("failed to replay modify kafka routine load job: {}", id, e);
+        }
+    }
+
+    private void modifyPropertiesInternal(Map<String, String> jobProperties,
+                                          PulsarDataSourceProperties dataSourceProperties) throws DdlException {
+        List<Pair<String, Long>> partitionInitialPositions = Lists.newArrayList();
+        Map<String, String> customPulsarProperties = Maps.newHashMap();
+
+        if (MapUtils.isNotEmpty(dataSourceProperties.getOriginalDataSourceProperties())) {
+            partitionInitialPositions = dataSourceProperties.getPulsarPartitionInitialPositions();
+            customPulsarProperties = dataSourceProperties.getCustomPulsarProperties();
+        }
+
+        if (!customPulsarProperties.isEmpty()) {
+            this.customProperties.putAll(customPulsarProperties);
+            convertCustomProperties(true);
+
+            if (customPulsarProperties.containsKey(PulsarConfiguration.PULSAR_DEFAULT_INITIAL_POSITION.getName())) {
+                // defaultInitialPosition should be updated by convertCustomProperties()
+                List<Pair<String, Long>> initialPositions = new ArrayList<>();
+                // defaultInitialPosition can only update currentPulsarPartitions
+                currentPulsarPartitions.forEach(
+                        entry -> initialPositions.add(Pair.of(entry, this.defaultInitialPosition)));
+                ((PulsarProgress) progress).modifyInitialPositions(initialPositions);
+            }
+        }
+
+        // modify partition positions
+        if (!partitionInitialPositions.isEmpty()) {
+            // we can only modify the partition if it's specified in the create statement
+            for (Pair<String, Long> pair : partitionInitialPositions) {
+                if (!customPulsarPartitions.contains(pair.first)) {
+                    throw new DdlException("The partition " + pair.first
+                        + " is not specified in the create statement");
+                }
+            }
+
+            ((PulsarProgress) progress).modifyInitialPositions(partitionInitialPositions);
+        }
+        if (!jobProperties.isEmpty()) {
+            Map<String, String> copiedJobProperties = Maps.newHashMap(jobProperties);
+            modifyCommonJobProperties(copiedJobProperties);
+            this.jobProperties.putAll(copiedJobProperties);
+            if (jobProperties.containsKey(CreateRoutineLoadStmt.PARTIAL_COLUMNS)) {
+                this.isPartialUpdate = BooleanUtils.toBoolean(jobProperties.get(CreateRoutineLoadStmt.PARTIAL_COLUMNS));
+            }
+        }
+        LOG.info("modify the data source properties of pulsar routine load job: {}, datasource properties: {}",
+                this.id, dataSourceProperties);
+    }
+
+    // check if given partitions has more data to consume.
+    public boolean hasMoreDataToConsume(UUID taskId, List<String> partitions, Map<String, Long> initialPositions) {
+        // Got initialPositions, we need to execute even there's no backlogs
+        if (!initialPositions.isEmpty()) {
+            LOG.debug("Got initialPositions, we need to execute even there's no backlogs. "
+                    + "partitions to be consumed: {}, initialPositions: {}, task {}, job {}",
+                    partitions, initialPositions, taskId, id);
+            return true;
+        }
+
+        try {
+            Map<String, Long> backlogNums = PulsarUtil.getBacklogNums(getServiceUrl(), getTopic(), getSubscription(),
+                    ImmutableMap.copyOf(getConvertedCustomProperties()), partitions);
+            for (String partition : partitions) {
+                Long backlogNum = backlogNums.get(partition);
+                if (backlogNum != null && backlogNum > 0) {
+                    return true;
+                }
+            }
+        } catch (UserException e) {
+            LOG.warn("failed to get back log num. {}", e.getMessage(), e);
+            return false;
+        }
+
+        LOG.debug("no more data to consume. partitions to be consumed: {}, "
+                + "initialPositions: {}, task {}, job {}",
+                partitions, initialPositions, taskId, id);
+        return false;
+    }
+
+    @Override
+    protected String getLag() {
+        Map<String, Long> partitionIdToOffsetLag = ((PulsarProgress) progress).getLag();
+        Gson gson = new Gson();
+        return gson.toJson(partitionIdToOffsetLag);
+    }
+
+    @Override
+    public TFileCompressType getCompressType() {
+        return TFileCompressType.PLAIN;
+    }
+
+    @Override
+    public double getMaxFilterRatio() {
+        return maxFilterRatio;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/PulsarTaskInfo.java
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+package org.apache.doris.load.routineload;
+
+import org.apache.doris.catalog.Database;
+import org.apache.doris.catalog.Env;
+import org.apache.doris.catalog.Table;
+import org.apache.doris.common.MetaNotFoundException;
+import org.apache.doris.common.UserException;
+import org.apache.doris.common.util.DebugUtil;
+import org.apache.doris.thrift.TExecPlanFragmentParams;
+import org.apache.doris.thrift.TFileFormatType;
+import org.apache.doris.thrift.TLoadSourceType;
+import org.apache.doris.thrift.TPlanFragment;
+import org.apache.doris.thrift.TPulsarLoadInfo;
+import org.apache.doris.thrift.TRoutineLoadTask;
+import org.apache.doris.thrift.TUniqueId;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class PulsarTaskInfo extends RoutineLoadTaskInfo {
+    private RoutineLoadManager routineLoadManager = Env.getCurrentEnv().getRoutineLoadManager();
+
+    private List<String> partitions;
+    private Map<String, Long> initialPositions = Maps.newHashMap();
+
+    public PulsarTaskInfo(UUID id, long jobId, String clusterName, List<String> partitions,
+                          Map<String, Long> initialPositions, long tastTimeoutMs, boolean isMultiTable) {
+        super(id, jobId, clusterName, tastTimeoutMs, isMultiTable);
+        this.partitions = partitions;
+        this.initialPositions.putAll(initialPositions);
+    }
+
+    public PulsarTaskInfo(PulsarTaskInfo pulsarTaskInfo, Map<String, Long> initialPositions, boolean isMultiTable) {
+        super(UUID.randomUUID(), pulsarTaskInfo.getJobId(), pulsarTaskInfo.getClusterName(),
+                pulsarTaskInfo.getTimeoutMs(), pulsarTaskInfo.getBeId(), isMultiTable);
+        this.partitions = pulsarTaskInfo.getPartitions();
+        this.initialPositions.putAll(initialPositions);
+    }
+
+    public List<String> getPartitions() {
+        return partitions;
+    }
+
+    public Map<String, Long> getInitialPositions() {
+        return initialPositions;
+    }
+
+    @Override
+    public TRoutineLoadTask createRoutineLoadTask() throws UserException {
+        PulsarRoutineLoadJob routineLoadJob = (PulsarRoutineLoadJob) routineLoadManager.getJob(jobId);
+
+        // init tRoutineLoadTask and create plan fragment
+        TRoutineLoadTask tRoutineLoadTask = new TRoutineLoadTask();
+        TUniqueId queryId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
+        tRoutineLoadTask.setId(queryId);
+        tRoutineLoadTask.setJobId(jobId);
+        tRoutineLoadTask.setTxnId(txnId);
+        Database database = Env.getCurrentInternalCatalog().getDbOrMetaException(routineLoadJob.getDbId());
+        tRoutineLoadTask.setDb(database.getFullName());
+        Table tbl = database.getTableNullable(routineLoadJob.getTableId());
+        if (tbl == null) {
+            throw new MetaNotFoundException("table " + routineLoadJob.getTableId() + " does not exist");
+        }
+        // label = job_name+job_id+task_id+txn_id
+        String label = Joiner.on("-").join(routineLoadJob.getName(),
+                routineLoadJob.getId(), DebugUtil.printId(id), txnId);
+        tRoutineLoadTask.setTbl(tbl.getName());
+        tRoutineLoadTask.setLabel(label);
+        tRoutineLoadTask.setAuthCode(routineLoadJob.getAuthCode());
+        TPulsarLoadInfo tPulsarLoadInfo = new TPulsarLoadInfo();
+        tPulsarLoadInfo.setServiceUrl((routineLoadJob).getServiceUrl());
+        tPulsarLoadInfo.setTopic((routineLoadJob).getTopic());
+        tPulsarLoadInfo.setSubscription((routineLoadJob).getSubscription());
+        tPulsarLoadInfo.setPartitions(getPartitions());
+        if (!initialPositions.isEmpty()) {
+            tPulsarLoadInfo.setInitialPositions(getInitialPositions());
+        }
+        tPulsarLoadInfo.setProperties(routineLoadJob.getConvertedCustomProperties());
+        tRoutineLoadTask.setPulsarLoadInfo(tPulsarLoadInfo);
+        tRoutineLoadTask.setType(TLoadSourceType.PULSAR);
+        tRoutineLoadTask.setIsMultiTable(isMultiTable);
+        tRoutineLoadTask.setParams(plan(routineLoadJob));
+        tRoutineLoadTask.setMaxIntervalS(routineLoadJob.getMaxBatchIntervalS());
+        tRoutineLoadTask.setMaxBatchRows(routineLoadJob.getMaxBatchRows());
+        tRoutineLoadTask.setMaxBatchSize(routineLoadJob.getMaxBatchSizeBytes());
+        if (!routineLoadJob.getFormat().isEmpty() && routineLoadJob.getFormat().equalsIgnoreCase("json")) {
+            tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_JSON);
+        } else {
+            tRoutineLoadTask.setFormat(TFileFormatType.FORMAT_CSV_PLAIN);
+        }
+        //if (Math.abs(routineLoadJob.getMaxFilterRatio() - 1) > 0.001) {
+        //    tRoutineLoadTask.setMaxFilterRatio(routineLoadJob.getMaxFilterRatio());
+        //}
+        return tRoutineLoadTask;
+    }
+
+    @Override
+    protected String getTaskDataSourceProperties() {
+        StringBuilder result = new StringBuilder();
+
+        Gson gson = new Gson();
+        result.append("Partitions: " + gson.toJson(partitions));
+        if (!initialPositions.isEmpty()) {
+            result.append("InitialPositisons: " + gson.toJson(initialPositions));
+        }
+
+        return result.toString();
+    }
+
+    @Override
+    boolean hasMoreDataToConsume() {
+        PulsarRoutineLoadJob routineLoadJob = (PulsarRoutineLoadJob) routineLoadManager.getJob(jobId);
+        return routineLoadJob.hasMoreDataToConsume(id, partitions, initialPositions);
+    }
+
+    @Override
+    public String toString() {
+        return "Task id: " + getId() + ", partitions: " + partitions + ", initial positions: " + initialPositions;
+    }
+
+    private TExecPlanFragmentParams plan(RoutineLoadJob routineLoadJob) throws UserException {
+        TUniqueId loadId = new TUniqueId(id.getMostSignificantBits(), id.getLeastSignificantBits());
+        // plan for each task, in case table has change(rollup or schema change)
+        TExecPlanFragmentParams tExecPlanFragmentParams = routineLoadJob.plan(loadId, txnId);
+        TPlanFragment tPlanFragment = tExecPlanFragmentParams.getFragment();
+        tPlanFragment.getOutputSink().getOlapTableSink().setTxnId(txnId);
+        return tExecPlanFragmentParams;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RLTaskTxnCommitAttachment.java
@@ -58,6 +58,9 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
             case KAFKA:
                 this.progress = new KafkaProgress(rlTaskTxnCommitAttachment.getKafkaRLTaskProgress());
                 break;
+            case PULSAR:
+                this.progress = new PulsarProgress(rlTaskTxnCommitAttachment.getPulsarRLTaskProgress());
+                break;
             default:
                 break;
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadDataSourcePropertyFactory.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadDataSourcePropertyFactory.java
@@ -18,6 +18,7 @@
 package org.apache.doris.load.routineload;
 
 import org.apache.doris.load.routineload.kafka.KafkaDataSourceProperties;
+import org.apache.doris.load.routineload.pulsar.PulsarDataSourceProperties;
 
 import java.util.Map;
 
@@ -37,6 +38,8 @@ public class RoutineLoadDataSourcePropertyFactory {
                                                                 boolean multiLoad) {
         if (type.equalsIgnoreCase(LoadDataSourceType.KAFKA.name())) {
             return new KafkaDataSourceProperties(parameters, multiLoad);
+        } else if (type.equalsIgnoreCase(LoadDataSourceType.PULSAR.name())) {
+            return new PulsarDataSourceProperties(parameters, multiLoad);
         }
         throw new IllegalArgumentException("Unknown routine load data source type: " + type);
     }
@@ -44,6 +47,8 @@ public class RoutineLoadDataSourcePropertyFactory {
     public static AbstractDataSourceProperties createDataSource(String type, Map<String, String> parameters) {
         if (type.equalsIgnoreCase(LoadDataSourceType.KAFKA.name())) {
             return new KafkaDataSourceProperties(parameters);
+        } else if (type.equalsIgnoreCase(LoadDataSourceType.PULSAR.name())) {
+            return new PulsarDataSourceProperties(parameters);
         }
         throw new IllegalArgumentException("Unknown routine load data source type: " + type);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadJob.java
@@ -1610,6 +1610,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         LoadDataSourceType type = LoadDataSourceType.valueOf(Text.readString(in));
         if (type == LoadDataSourceType.KAFKA) {
             job = new KafkaRoutineLoadJob();
+        } else if (type == LoadDataSourceType.PULSAR) {
+            job = new PulsarRoutineLoadJob();
         } else {
             throw new IOException("Unknown load data source type: " + type.name());
         }
@@ -1689,6 +1691,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         switch (dataSourceType) {
             case KAFKA: {
                 progress = new KafkaProgress();
+                progress.readFields(in);
+                break;
+            }
+            case PULSAR: {
+                progress = new PulsarProgress();
                 progress.readFields(in);
                 break;
             }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadManager.java
@@ -169,6 +169,9 @@ public class RoutineLoadManager implements Writable {
             case KAFKA:
                 routineLoadJob = KafkaRoutineLoadJob.fromCreateStmt(createRoutineLoadStmt);
                 break;
+            case PULSAR:
+                routineLoadJob = PulsarRoutineLoadJob.fromCreateStmt(createRoutineLoadStmt);
+                break;
             default:
                 throw new UserException("Unknown data source type: " + type);
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadProgress.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadProgress.java
@@ -46,6 +46,8 @@ public abstract class RoutineLoadProgress implements Writable {
         LoadDataSourceType type = LoadDataSourceType.valueOf(Text.readString(in));
         if (type == LoadDataSourceType.KAFKA) {
             progress = new KafkaProgress();
+        } else if (type == LoadDataSourceType.PULSAR) {
+            progress = new PulsarProgress();
         } else {
             throw new IOException("Unknown load data source type: " + type.name());
         }

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/RoutineLoadTaskScheduler.java
@@ -212,6 +212,10 @@ public class RoutineLoadTaskScheduler extends MasterDaemon {
                 LOG.debug("send kafka routine load task {} with partition offset: {}, job: {}",
                         tRoutineLoadTask.label, tRoutineLoadTask.kafka_load_info.partition_begin_offset,
                         tRoutineLoadTask.getJobId());
+            } else if (tRoutineLoadTask.isSetPulsarLoadInfo()) {
+                LOG.debug("send pulsar routine load task {} with partitions: {}, job: {}",
+                        tRoutineLoadTask.label, tRoutineLoadTask.pulsar_load_info.partitions,
+                        tRoutineLoadTask.getJobId());
             }
         } catch (LoadException e) {
             // submit task failed (such as TOO_MANY_TASKS error), but txn has already begun.

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/pulsar/PulsarConfiguration.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/pulsar/PulsarConfiguration.java
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load.routineload.pulsar;
+
+import java.util.Arrays;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum PulsarConfiguration {
+
+    PULSAR_SERVICE_URL_PROPERTY("pulsar_service_url", null, value -> value.replace(" ", "")),
+
+    PULSAR_TOPIC_PROPERTY("pulsar_topic", null, value -> value.replace(" ", "")),
+
+    PULSAR_SUBSCRIPTION_PROPERTY("pulsar_subscription", null, value -> value.replace(" ", "")),
+
+    PULSAR_PARTITIONS_PROPERTY("pulsar_partitions", null, partitionsString ->
+        Arrays.stream(partitionsString.replace(" ", "").split(","))
+            .collect(Collectors.toList())),
+
+    PULSAR_INITIAL_POSITIONS_PROPERTY("pulsar_initial_positions", null, partitionsString ->
+        Arrays.stream(partitionsString.replace(" ", "").split(","))
+            .collect(Collectors.toList())),
+    PULSAR_DEFAULT_INITIAL_POSITION("pulsar_default_initial_position", "POSITION_EARLIEST", position -> position);
+    private final String name;
+
+    public String getName() {
+        return name;
+    }
+
+    private final Object defaultValue;
+
+    private final Function<String, Object> converter;
+
+    <T> PulsarConfiguration(String name, T defaultValue, Function<String, T> converter) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.converter = (Function<String, Object>) converter;
+    }
+
+    PulsarConfiguration getByName(String name) {
+        return Arrays.stream(PulsarConfiguration.values())
+            .filter(config -> config.getName().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException("Unknown configuration " + name));
+    }
+
+
+    public <T> T getParameterValue(String param) {
+        Object value = param != null ? converter.apply(param) : defaultValue;
+        return (T) value;
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/load/routineload/pulsar/PulsarDataSourceProperties.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/load/routineload/pulsar/PulsarDataSourceProperties.java
@@ -1,0 +1,250 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.doris.load.routineload.pulsar;
+
+import org.apache.doris.common.AnalysisException;
+import org.apache.doris.common.Pair;
+import org.apache.doris.common.UserException;
+import org.apache.doris.load.routineload.AbstractDataSourceProperties;
+import org.apache.doris.load.routineload.LoadDataSourceType;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Pulsar data source properties
+ */
+public class PulsarDataSourceProperties extends AbstractDataSourceProperties {
+
+    private static final String ENDPOINT_REGEX = "[-A-Za-z0-9+&@#/%?=~_|!:,.;]+[-A-Za-z0-9+&@#/%=~_|]";
+
+    private static final String CUSTOM_KAFKA_PROPERTY_PREFIX = "property.";
+
+    public static final String POSITION_EARLIEST = "POSITION_EARLIEST"; // 1
+    public static final String POSITION_LATEST = "POSITION_LATEST"; // 0
+    public static final long POSITION_LATEST_VAL = 0;
+    public static final long POSITION_EARLIEST_VAL = 1;
+
+    @Getter
+    @SerializedName(value = "pulsarServiceUrl")
+    private String pulsarServiceUrl;
+
+    @Getter
+    @SerializedName(value = "pulsarTopic")
+    private String pulsarTopic;
+
+    @Getter
+    @SerializedName(value = "pulsarSubscription")
+    private String pulsarSubscription;
+
+    @Getter
+    @SerializedName(value = "pulsarPartitions")
+    private List<String> pulsarPartitions = Lists.newArrayList();
+
+
+    @Getter
+    @Setter
+    @SerializedName(value = "pulsarPartitionInitialPositions")
+    private List<Pair<String, Long>> pulsarPartitionInitialPositions = Lists.newArrayList();
+
+
+    @Getter
+    @SerializedName(value = "customPulsarProperties")
+    private Map<String, String> customPulsarProperties = Maps.newHashMap();
+
+    private static final ImmutableSet<String> CONFIGURABLE_DATA_SOURCE_PROPERTIES_SET =
+            new ImmutableSet.Builder<String>().add(PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName())
+            .add(PulsarConfiguration.PULSAR_TOPIC_PROPERTY.getName())
+            .add(PulsarConfiguration.PULSAR_SUBSCRIPTION_PROPERTY.getName())
+            .add(PulsarConfiguration.PULSAR_PARTITIONS_PROPERTY.getName())
+            .add(PulsarConfiguration.PULSAR_INITIAL_POSITIONS_PROPERTY.getName())
+            .build();
+
+    public PulsarDataSourceProperties(Map<String, String> dataSourceProperties, boolean multiLoad) {
+        super(dataSourceProperties, multiLoad);
+    }
+
+    public PulsarDataSourceProperties(Map<String, String> originalDataSourceProperties) {
+        super(originalDataSourceProperties);
+    }
+
+    @Override
+    protected String getDataSourceType() {
+        return LoadDataSourceType.PULSAR.name();
+    }
+
+    @Override
+    protected List<String> getRequiredProperties() throws UserException {
+        return Arrays.asList(PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName(),
+            PulsarConfiguration.PULSAR_TOPIC_PROPERTY.getName());
+    }
+
+    @Override
+    public void convertAndCheckDataSourceProperties() throws UserException {
+        Optional<String> optional = originalDataSourceProperties.keySet().stream()
+                .filter(entity -> !CONFIGURABLE_DATA_SOURCE_PROPERTIES_SET.contains(entity))
+                .filter(entity -> !entity.startsWith("property.")).findFirst();
+        if (optional.isPresent()) {
+            throw new AnalysisException(optional.get() + " is invalid pulsar custom property");
+        }
+
+        // check service url
+        pulsarServiceUrl = Strings.nullToEmpty(originalDataSourceProperties.get(
+            PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName())).replaceAll(" ", "");
+        if (Strings.isNullOrEmpty(pulsarServiceUrl)) {
+            throw new AnalysisException(PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName()
+                + " is a required property");
+        }
+
+        String[] pulsarServiceUrlList = this.pulsarServiceUrl.split(",");
+        for (String serviceUrl : pulsarServiceUrlList) {
+            if (!Pattern.matches(ENDPOINT_REGEX, serviceUrl)) {
+                throw new AnalysisException(PulsarConfiguration.PULSAR_SERVICE_URL_PROPERTY.getName() + ":" + serviceUrl
+                    + " not match pattern " + ENDPOINT_REGEX);
+            }
+        }
+
+        // check topic
+        pulsarTopic = Strings.nullToEmpty(originalDataSourceProperties.get(
+            PulsarConfiguration.PULSAR_TOPIC_PROPERTY.getName())).replaceAll(" ", "");
+        if (Strings.isNullOrEmpty(pulsarTopic)) {
+            throw new AnalysisException(PulsarConfiguration.PULSAR_TOPIC_PROPERTY + " is a required property");
+        }
+
+        // check subscription
+        pulsarSubscription = Strings.nullToEmpty(originalDataSourceProperties.get(
+            PulsarConfiguration.PULSAR_SUBSCRIPTION_PROPERTY.getName())).replaceAll(" ", "");
+        if (Strings.isNullOrEmpty(pulsarSubscription)) {
+            throw new AnalysisException(PulsarConfiguration.PULSAR_SUBSCRIPTION_PROPERTY + " is a required property");
+        }
+
+        // check custom pulsar property before check partitions,
+        // because partitions can use pulsar_default_position property
+        analyzePulsarCustomProperties(originalDataSourceProperties, customPulsarProperties);
+
+        // check partitions
+        String pulsarPartitionsString = originalDataSourceProperties.get(
+                PulsarConfiguration.PULSAR_PARTITIONS_PROPERTY.getName());
+        if (pulsarPartitionsString != null) {
+            analyzePulsarPartitionProperty(pulsarPartitionsString, customPulsarProperties, pulsarPartitions,
+                    pulsarPartitionInitialPositions);
+        }
+
+        // check positions
+        String pulsarPositionString = originalDataSourceProperties.get(
+                PulsarConfiguration.PULSAR_INITIAL_POSITIONS_PROPERTY.getName());
+        if (pulsarPositionString != null) {
+            analyzePulsarPositionProperty(pulsarPositionString, pulsarPartitions, pulsarPartitionInitialPositions);
+        }
+    }
+
+    public static void analyzePulsarPartitionProperty(String pulsarPartitionsString,
+                                                      Map<String, String> customPulsarProperties,
+                                                      List<String> pulsarPartitions,
+                                                      List<Pair<String, Long>> pulsarPartitionInitialPositions)
+            throws AnalysisException {
+        pulsarPartitionsString = pulsarPartitionsString.replaceAll(" ", "");
+        if (pulsarPartitionsString.isEmpty()) {
+            throw new AnalysisException(PulsarConfiguration.PULSAR_PARTITIONS_PROPERTY
+                + " could not be a empty string");
+        }
+
+        String[] pulsarPartitionsStringList = pulsarPartitionsString.split(",");
+        for (String s : pulsarPartitionsStringList) {
+            pulsarPartitions.add(s);
+        }
+
+        // get default initial positions if set
+        if (customPulsarProperties.containsKey(PulsarConfiguration.PULSAR_DEFAULT_INITIAL_POSITION.getName())) {
+            Long pulsarDefaultInitialPosition = getPulsarPosition(customPulsarProperties.get(
+                    PulsarConfiguration.PULSAR_DEFAULT_INITIAL_POSITION.getName()));
+            pulsarPartitions.stream().forEach(
+                    entry -> pulsarPartitionInitialPositions.add(Pair.of(entry, pulsarDefaultInitialPosition)));
+        }
+    }
+
+    public static void analyzePulsarPositionProperty(String pulsarPositionsString,
+                                                     List<String> pulsarPartitions,
+                                                     List<Pair<String, Long>> pulsarPartitionInitialPositions)
+            throws AnalysisException {
+        pulsarPositionsString = pulsarPositionsString.replaceAll(" ", "");
+        if (pulsarPositionsString.isEmpty()) {
+            throw new AnalysisException(PulsarConfiguration.PULSAR_INITIAL_POSITIONS_PROPERTY.getName()
+                + " could not be a empty string");
+        }
+        String[] pulsarPositionsStringList = pulsarPositionsString.split(",");
+        if (pulsarPositionsStringList.length != pulsarPartitions.size()) {
+            throw new AnalysisException("Partitions number should be equals to positions number");
+        }
+
+        if (!pulsarPartitionInitialPositions.isEmpty()) {
+            for (int i = 0; i < pulsarPositionsStringList.length; i++) {
+                pulsarPartitionInitialPositions.get(i).second = getPulsarPosition(pulsarPositionsStringList[i]);
+            }
+        } else {
+            for (int i = 0; i < pulsarPositionsStringList.length; i++) {
+                pulsarPartitionInitialPositions.add(Pair.of(pulsarPartitions.get(i),
+                        getPulsarPosition(pulsarPositionsStringList[i])));
+            }
+        }
+    }
+
+    // Get pulsar position from string
+    // defined in pulsar-client-cpp/InitialPosition.h
+    // InitialPositionLatest: 0
+    // InitialPositionEarliest: 1
+    public static long getPulsarPosition(String positionStr) throws AnalysisException {
+        long position;
+        if (positionStr.equalsIgnoreCase(POSITION_EARLIEST)) {
+            position = POSITION_EARLIEST_VAL;
+        } else if (positionStr.equalsIgnoreCase(POSITION_LATEST)) {
+            position = POSITION_LATEST_VAL;
+        } else {
+            throw new AnalysisException("Only POSITION_EARLIEST or POSITION_LATEST can be specified");
+        }
+        return position;
+    }
+
+    public static void analyzePulsarCustomProperties(Map<String, String> dataSourceProperties,
+                                                     Map<String, String> customPulsarProperties)
+            throws AnalysisException {
+        for (Map.Entry<String, String> dataSourceProperty : dataSourceProperties.entrySet()) {
+            if (dataSourceProperty.getKey().startsWith("property.")) {
+                String propertyKey = dataSourceProperty.getKey();
+                String propertyValue = dataSourceProperty.getValue();
+                String[] propertyValueArr = propertyKey.split("\\.");
+                if (propertyValueArr.length < 2) {
+                    throw new AnalysisException("pulsar property value could not be a empty string");
+                }
+                customPulsarProperties.put(propertyKey.substring(propertyKey.indexOf(".") + 1), propertyValue);
+            }
+            // can be extended in the future which other prefix
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceClient.java
@@ -121,6 +121,10 @@ public class BackendServiceClient {
         return stub.getInfo(request);
     }
 
+    public Future<InternalService.PPulsarProxyResult> getPulsarInfo(InternalService.PPulsarProxyRequest request) {
+        return stub.getPulsarInfo(request);
+    }
+
     public Future<InternalService.PSendDataResult> sendData(InternalService.PSendDataRequest request) {
         return stub.sendData(request);
     }

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -316,6 +316,17 @@ public class BackendServiceProxy {
         }
     }
 
+    public Future<InternalService.PPulsarProxyResult> getPulsarInfo(
+        TNetworkAddress address, InternalService.PPulsarProxyRequest request) throws RpcException {
+        try {
+            final BackendServiceClient client = getProxy(address);
+            return client.getPulsarInfo(request);
+        } catch (Throwable e) {
+            LOG.warn("failed to get pulsar info, address={}:{}", address.getHostname(), address.getPort(), e);
+            throw new RpcException(address.hostname, e.getMessage());
+        }
+    }
+
     public Future<InternalService.PSendDataResult> sendData(
             TNetworkAddress address, Types.PUniqueId fragmentInstanceId,
             Types.PUniqueId loadId, List<InternalService.PDataRow> data)

--- a/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
+++ b/fe/fe-core/src/main/java/org/apache/doris/rpc/BackendServiceProxy.java
@@ -317,7 +317,7 @@ public class BackendServiceProxy {
     }
 
     public Future<InternalService.PPulsarProxyResult> getPulsarInfo(
-        TNetworkAddress address, InternalService.PPulsarProxyRequest request) throws RpcException {
+            TNetworkAddress address, InternalService.PPulsarProxyRequest request) throws RpcException {
         try {
             final BackendServiceClient client = getProxy(address);
             return client.getPulsarInfo(request);

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -382,6 +382,53 @@ message PProxyResult {
 	optional PKafkaPartitionOffsets partition_offsets = 3;
 };
 
+message PPulsarLoadInfo {
+  required string service_url = 1;
+  required string topic = 2;
+  required string subscription = 3;
+  repeated PStringPair properties = 4;
+};
+
+message PPulsarMetaProxyRequest {
+  optional PPulsarLoadInfo pulsar_info = 1;
+};
+
+message PPulsarBacklogProxyRequest {
+  optional PPulsarLoadInfo pulsar_info = 1;
+  repeated string partitions = 2;
+};
+
+message PPulsarBacklogBatchProxyRequest {
+  repeated PPulsarBacklogProxyRequest requests = 1;
+};
+
+message PPulsarProxyRequest {
+  optional PPulsarMetaProxyRequest pulsar_meta_request = 1;
+  optional PPulsarBacklogProxyRequest pulsar_backlog_request = 101;
+  optional PPulsarBacklogBatchProxyRequest pulsar_backlog_batch_request = 102;
+  optional int64 timeout = 103;
+};
+
+message PPulsarMetaProxyResult {
+  repeated string partitions = 1;
+};
+
+message PPulsarBacklogProxyResult {
+  repeated string partitions = 1;
+  repeated int64 backlog_nums = 2;
+}
+
+message PPulsarBacklogBatchProxyResult {
+  repeated PPulsarBacklogProxyResult results = 1;
+}
+
+message PPulsarProxyResult {
+  required PStatus status = 1;
+  optional PPulsarMetaProxyResult pulsar_meta_result = 2;
+  optional PPulsarBacklogProxyResult pulsar_backlog_result = 101;
+  optional PPulsarBacklogBatchProxyResult pulsar_backlog_batch_result = 102;
+};
+
 message PDataColumn {
     optional string value = 1;
 }
@@ -722,5 +769,6 @@ service PBackendService {
     rpc get_column_ids_by_tablet_ids(PFetchColIdsRequest) returns (PFetchColIdsResponse);
     rpc get_tablet_rowset_versions(PGetTabletVersionsRequest) returns (PGetTabletVersionsResponse);
     rpc glob(PGlobRequest) returns (PGlobResponse);
+    rpc get_pulsar_info(PPulsarProxyRequest) returns (PPulsarProxyResult);
 };
 

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -50,6 +50,15 @@ struct TKafkaLoadInfo {
     4: optional map<string, string> properties;
 }
 
+struct TPulsarLoadInfo {
+    1: required string service_url;
+    2: required string topic;
+    3: required string subscription;
+    4: required list<string> partitions;
+    5: optional map<string, i64> initial_positions;
+    6: optional map<string, string> properties;
+}
+
 struct TRoutineLoadTask {
     1: required Types.TLoadSourceType type
     2: required i64 job_id
@@ -67,6 +76,7 @@ struct TRoutineLoadTask {
     14: optional PlanNodes.TFileFormatType format
     15: optional PaloInternalService.TPipelineFragmentParams pipeline_params
     16: optional bool is_multi_table
+    17: optional TPulsarLoadInfo pulsar_load_info
 }
 
 struct TKafkaMetaProxyRequest {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -647,6 +647,10 @@ struct TKafkaRLTaskProgress {
     1: required map<i32,i64> partitionCmtOffset
 }
 
+struct TPulsarRLTaskProgress {
+    1: required map<string,i64> partitionBacklogNum
+}
+
 struct TRLTaskTxnCommitAttachment {
     1: required Types.TLoadSourceType loadSourceType
     2: required Types.TUniqueId id
@@ -659,6 +663,7 @@ struct TRLTaskTxnCommitAttachment {
     9: optional i64 loadCostMs
     10: optional TKafkaRLTaskProgress kafkaRLTaskProgress
     11: optional string errorLogUrl
+    12: optional TPulsarRLTaskProgress pulsarRLTaskProgress
 }
 
 struct TTxnCommitAttachment {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -672,6 +672,7 @@ enum TLoadSourceType {
     RAW,
     KAFKA,
     MULTI_TABLE,
+    PULSAR,
 }
 
 enum TMergeType {

--- a/thirdparty/build-thirdparty-pulsar.sh
+++ b/thirdparty/build-thirdparty-pulsar.sh
@@ -1,0 +1,538 @@
+#!/usr/bin/env bash
+# shellcheck disable=2034
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#################################################################################
+# This script will
+# 1. Check prerequisite libraries. Including:
+#    cmake byacc flex automake libtool binutils-dev libiberty-dev bison
+# 2. Compile and install all thirdparties which are downloaded
+#    using *download-thirdparty.sh*.
+#
+# This script will run *download-thirdparty.sh* once again
+# to check if all thirdparties have been downloaded, unpacked and patched.
+#################################################################################
+
+set -eo pipefail
+
+curdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+export DORIS_HOME="${curdir}/.."
+export TP_DIR="${curdir}"
+
+# include custom environment variables
+if [[ -f "${DORIS_HOME}/env.sh" ]]; then
+    export BUILD_THIRDPARTY_WIP=1
+    . "${DORIS_HOME}/env.sh"
+    export BUILD_THIRDPARTY_WIP=
+fi
+
+# Check args
+usage() {
+    echo "
+Usage: $0 [options...] [packages...]
+  Optional options:
+     -j <num>               build thirdparty parallel
+     --clean                clean the extracted data
+     --continue <package>   continue to build the remaining packages (starts from the specified package)
+  "
+    exit 1
+}
+
+if ! OPTS="$(getopt \
+    -n "$0" \
+    -o 'hj:' \
+    -l 'help,clean,continue:' \
+    -- "$@")"; then
+    usage
+fi
+
+eval set -- "${OPTS}"
+
+KERNEL="$(uname -s)"
+
+if [[ "${KERNEL}" == 'Darwin' ]]; then
+    PARALLEL="$(($(sysctl -n hw.logicalcpu) / 4 + 1))"
+else
+    PARALLEL="$(($(nproc) / 4 + 1))"
+fi
+
+while true; do
+    case "$1" in
+    -j)
+        PARALLEL="$2"
+        shift 2
+        ;;
+    -h)
+        HELP=1
+        shift
+        ;;
+    --help)
+        HELP=1
+        shift
+        ;;
+    --clean)
+        CLEAN=1
+        shift
+        ;;
+    --continue)
+        CONTINUE=1
+        start_package="${2}"
+        shift 2
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Internal error"
+        exit 1
+        ;;
+    esac
+done
+
+if [[ "${CONTINUE}" -eq 1 ]]; then
+    if [[ -z "${start_package}" ]] || [[ "${#}" -ne 0 ]]; then
+        usage
+    fi
+fi
+
+read -r -a packages <<<"${@}"
+
+if [[ "${HELP}" -eq 1 ]]; then
+    usage
+fi
+
+echo "Get params:
+    PARALLEL            -- ${PARALLEL}
+    CLEAN               -- ${CLEAN}
+    PACKAGES            -- ${packages[*]}
+    CONTINUE            -- ${start_package}
+"
+
+if [[ ! -f "${TP_DIR}/download-thirdparty.sh" ]]; then
+    echo "Download thirdparty script is missing".
+    exit 1
+fi
+
+if [[ ! -f "${TP_DIR}/vars.sh" ]]; then
+    echo "vars.sh is missing".
+    exit 1
+fi
+
+. "${TP_DIR}/vars.sh"
+
+cd "${TP_DIR}"
+
+if [[ "${CLEAN}" -eq 1 ]] && [[ -d "${TP_SOURCE_DIR}" ]]; then
+    echo 'Clean the extracted data ...'
+    find "${TP_SOURCE_DIR}" -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
+    echo 'Success!'
+fi
+
+# Download thirdparties.
+"${TP_DIR}/download-thirdparty.sh"
+
+export LD_LIBRARY_PATH="${TP_DIR}/installed/lib:${LD_LIBRARY_PATH}"
+
+# toolchain specific warning options and settings
+if [[ "${CC}" == *gcc ]]; then
+    warning_uninitialized='-Wno-maybe-uninitialized'
+    warning_stringop_truncation='-Wno-stringop-truncation'
+    warning_class_memaccess='-Wno-class-memaccess'
+    warning_array_parameter='-Wno-array-parameter'
+    warning_narrowing='-Wno-narrowing'
+    warning_dangling_reference='-Wno-dangling-reference'
+    boost_toolset='gcc'
+elif [[ "${CC}" == *clang ]]; then
+    warning_uninitialized='-Wno-uninitialized'
+    warning_shadow='-Wno-shadow'
+    warning_dangling_gsl='-Wno-dangling-gsl'
+    warning_unused_but_set_variable='-Wno-unused-but-set-variable'
+    warning_defaulted_function_deleted='-Wno-defaulted-function-deleted'
+    warning_reserved_identifier='-Wno-reserved-identifier'
+    warning_suggest_override='-Wno-suggest-override -Wno-suggest-destructor-override'
+    warning_option_ignored='-Wno-option-ignored'
+    warning_narrowing='-Wno-c++11-narrowing'
+    boost_toolset='clang'
+    libhdfs_cxx17='-std=c++1z'
+
+    test_warning_result="$("${CC}" -xc++ "${warning_unused_but_set_variable}" /dev/null 2>&1 || true)"
+    if echo "${test_warning_result}" | grep 'unknown warning option' >/dev/null; then
+        warning_unused_but_set_variable=''
+    fi
+fi
+
+# prepare installed prefix
+mkdir -p "${TP_DIR}/installed/lib64"
+pushd "${TP_DIR}/installed"/
+ln -sf lib64 lib
+popd
+
+# Configure the search paths for pkg-config and cmake
+export PKG_CONFIG_PATH="${TP_DIR}/installed/lib64/pkgconfig"
+export CMAKE_PREFIX_PATH="${TP_DIR}/installed"
+
+echo "PKG_CONFIG_PATH: ${PKG_CONFIG_PATH}"
+echo "CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}"
+
+check_prerequest() {
+    local CMD="$1"
+    local NAME="$2"
+    if ! eval "${CMD}"; then
+        echo "${NAME} is missing"
+        exit 1
+    else
+        echo "${NAME} is found"
+    fi
+}
+
+# sudo apt-get install cmake
+# sudo yum install cmake
+check_prerequest "${CMAKE_CMD} --version" "cmake"
+
+# sudo apt-get install byacc
+# sudo yum install byacc
+check_prerequest "byacc -V" "byacc"
+
+# sudo apt-get install flex
+# sudo yum install flex
+check_prerequest "flex -V" "flex"
+
+# sudo apt-get install automake
+# sudo yum install automake
+check_prerequest "automake --version" "automake"
+
+# sudo apt-get install libtool
+# sudo yum install libtool
+check_prerequest "libtoolize --version" "libtool"
+
+# aclocal_version should equal to automake_version
+aclocal_version=$(aclocal --version | sed -n '1p' | awk 'NF>1{print $NF}')
+automake_version=$(automake --version | sed -n '1p' | awk 'NF>1{print $NF}')
+if [[ "${aclocal_version}" != "${automake_version}" ]]; then
+    echo "Error: aclocal version(${aclocal_version}) is not equal to automake version(${automake_version})."
+    exit 1
+fi
+
+# sudo apt-get install binutils-dev
+# sudo yum install binutils-devel
+#check_prerequest "locate libbfd.a" "binutils-dev"
+
+# sudo apt-get install libiberty-dev
+# no need in centos 7.1
+#check_prerequest "locate libiberty.a" "libiberty-dev"
+
+# sudo apt-get install bison
+# sudo yum install bison
+# necessary only when compiling be
+#check_prerequest "bison --version" "bison"
+
+#########################
+# build all thirdparties
+#########################
+
+# Name of cmake build directory in each thirdpary project.
+# Do not use `build`, because many projects contained a file named `BUILD`
+# and if the filesystem is not case sensitive, `mkdir` will fail.
+BUILD_DIR=doris_build
+
+check_if_source_exist() {
+    if [[ -z $1 ]]; then
+        echo "dir should specified to check if exist."
+        exit 1
+    fi
+
+    if [[ ! -d "${TP_SOURCE_DIR}/$1" ]]; then
+        echo "${TP_SOURCE_DIR}/$1 does not exist."
+        exit 1
+    fi
+    echo "===== begin build $1"
+}
+
+check_if_archive_exist() {
+    if [[ -z $1 ]]; then
+        echo "archive should specified to check if exist."
+        exit 1
+    fi
+
+    if [[ ! -f "${TP_SOURCE_DIR}/$1" ]]; then
+        echo "${TP_SOURCE_DIR}/$1 does not exist."
+        exit 1
+    fi
+}
+
+remove_all_dylib() {
+    if [[ "${KERNEL}" == 'Darwin' ]]; then
+        find "${TP_INSTALL_DIR}/lib64" -name "*.dylib" -delete
+    fi
+}
+
+if [[ -z "${STRIP_TP_LIB}" ]]; then
+    if [[ "${KERNEL}" != 'Darwin' ]]; then
+        STRIP_TP_LIB='ON'
+    else
+        STRIP_TP_LIB='OFF'
+    fi
+fi
+
+if [[ "${STRIP_TP_LIB}" = "ON" ]]; then
+    echo "Strip thirdparty libraries"
+else
+    echo "Do not strip thirdparty libraries"
+fi
+
+strip_lib() {
+    if [[ "${STRIP_TP_LIB}" = "ON" ]]; then
+        if [[ -z $1 ]]; then
+            echo "Must specify the library to be stripped."
+            exit 1
+        fi
+        if [[ ! -f "${TP_LIB_DIR}/$1" ]]; then
+            echo "Library to be stripped (${TP_LIB_DIR}/$1) does not exist."
+            exit 1
+        fi
+        strip --strip-debug --strip-unneeded "${TP_LIB_DIR}/$1"
+    fi
+}
+
+build_openssl() {
+    MACHINE_TYPE="$(uname -m)"
+    OPENSSL_PLATFORM="linux-x86_64"
+    if [[ "${KERNEL}" == 'Darwin' ]]; then
+        OPENSSL_PLATFORM="darwin64-${MACHINE_TYPE}-cc"
+    elif [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
+        OPENSSL_PLATFORM="linux-aarch64"
+    fi
+
+    check_if_source_exist "${OPENSSL_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${OPENSSL_SOURCE}"
+
+    CPPFLAGS="-I${TP_INCLUDE_DIR}" \
+        CXXFLAGS="-I${TP_INCLUDE_DIR}" \
+        LDFLAGS="-L${TP_LIB_DIR}" \
+        LIBDIR="lib" \
+        ./Configure --prefix="${TP_INSTALL_DIR}" --with-rand-seed=devrandom -shared "${OPENSSL_PLATFORM}"
+    # NOTE(amos): Never use '&&' to concat commands as it will eat error code
+    # See https://mywiki.wooledge.org/BashFAQ/105 for more detail.
+    make -j "${PARALLEL}"
+    make install_sw
+    # NOTE(zc): remove this dynamic library files to make libcurl static link.
+    # If I don't remove this files, I don't known how to make libcurl link static library
+    if [[ -f "${TP_INSTALL_DIR}/lib64/libcrypto.so" ]]; then
+        rm -rf "${TP_INSTALL_DIR}"/lib64/libcrypto.so*
+    fi
+    if [[ -f "${TP_INSTALL_DIR}/lib64/libssl.so" ]]; then
+        rm -rf "${TP_INSTALL_DIR}"/lib64/libssl.so*
+    fi
+    remove_all_dylib
+}
+
+# zlib
+build_zlib() {
+    check_if_source_exist "${ZLIB_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${ZLIB_SOURCE}"
+
+    CFLAGS="-O3 -fPIC" \
+        CPPFLAGS="-I${TP_INCLUDE_DIR}" \
+        LDFLAGS="-L${TP_LIB_DIR}" \
+        ./configure --prefix="${TP_INSTALL_DIR}"
+
+    make -j "${PARALLEL}"
+    make install
+
+    # minizip
+    cd contrib/minizip
+    autoreconf --force --install
+    ./configure --prefix="${TP_INSTALL_DIR}" --enable-static=yes --enable-shared=no
+    make -j "${PARALLEL}"
+    make install
+}
+
+# zstd
+build_zstd() {
+    check_if_source_exist "${ZSTD_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${ZSTD_SOURCE}/build/cmake"
+
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+
+    "${CMAKE_CMD}" -G "${GENERATOR}" -DBUILD_TESTING=OFF -DZSTD_BUILD_TESTS=OFF -DZSTD_BUILD_STATIC=ON \
+        -DZSTD_BUILD_PROGRAMS=OFF -DZSTD_BUILD_SHARED=OFF -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" ..
+
+    "${BUILD_SYSTEM}" -j "${PARALLEL}" install
+    strip_lib libzstd.a
+}
+
+# boost
+build_boost() {
+    check_if_source_exist "${BOOST_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${BOOST_SOURCE}"
+
+    if [[ "${KERNEL}" != 'Darwin' ]]; then
+        cxxflags='-static'
+    else
+        cxxflags=''
+    fi
+
+    CXXFLAGS="${cxxflags}" \
+        ./bootstrap.sh --prefix="${TP_INSTALL_DIR}" --with-toolset="${boost_toolset}"
+    # -q: Fail at first error
+    ./b2 -q link=static runtime-link=static -j "${PARALLEL}" \
+        --without-mpi --without-graph --without-graph_parallel --without-python \
+        cxxflags="-std=c++17 -g -I${TP_INCLUDE_DIR} -L${TP_LIB_DIR}" install
+}
+
+# gtest
+build_gtest() {
+    check_if_source_exist "${GTEST_SOURCE}"
+
+    cd "${TP_SOURCE_DIR}/${GTEST_SOURCE}"
+
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+
+    rm -rf CMakeCache.txt CMakeFiles/
+    "${CMAKE_CMD}" ../ -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" -DCMAKE_POSITION_INDEPENDENT_CODE=On
+    # -DCMAKE_CXX_FLAGS="$warning_uninitialized"
+
+    "${BUILD_SYSTEM}" -j "${PARALLEL}"
+    "${BUILD_SYSTEM}" install
+    strip_lib libgtest.a
+}
+
+# protobuf
+build_protobuf() {
+    check_if_source_exist "${PROTOBUF_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${PROTOBUF_SOURCE}"
+
+    if [[ "${KERNEL}" == 'Darwin' ]]; then
+        ldflags="-L${TP_LIB_DIR}"
+    else
+        ldflags="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc -Wl,--undefined=pthread_create"
+    fi
+
+    mkdir -p cmake/build
+    cd cmake/build
+
+    CXXFLAGS="-O2 -I${TP_INCLUDE_DIR}" \
+        LDFLAGS="${ldflags}" \
+        "${CMAKE_CMD}" -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" \
+        -Dprotobuf_USE_EXTERNAL_GTEST=ON \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -Dprotobuf_BUILD_SHARED_LIBS=OFF \
+        -Dprotobuf_BUILD_TESTS=OFF \
+        -Dprotobuf_WITH_ZLIB_DEFAULT=ON \
+        -Dprotobuf_ABSL_PROVIDER=package \
+        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" ../..
+
+    make -j "${PARALLEL}"
+    make install
+    strip_lib libprotobuf.a
+    strip_lib libprotoc.a
+}
+
+# snappy
+build_snappy() {
+    check_if_source_exist "${SNAPPY_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${SNAPPY_SOURCE}"
+
+    mkdir -p "${BUILD_DIR}"
+    cd "${BUILD_DIR}"
+
+    rm -rf CMakeCache.txt CMakeFiles/
+
+    CFLAGS="-O3" CXXFLAGS="-O3" "${CMAKE_CMD}" -G "${GENERATOR}" -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_INSTALL_INCLUDEDIR="${TP_INCLUDE_DIR}"/snappy \
+        -DSNAPPY_BUILD_TESTS=0 ../
+
+    "${BUILD_SYSTEM}" -j "${PARALLEL}"
+    "${BUILD_SYSTEM}" install
+
+    #build for libarrow.a
+    cp "${TP_INCLUDE_DIR}/snappy/snappy-c.h" "${TP_INCLUDE_DIR}/snappy-c.h"
+    cp "${TP_INCLUDE_DIR}/snappy/snappy-sinksource.h" "${TP_INCLUDE_DIR}/snappy-sinksource.h"
+    cp "${TP_INCLUDE_DIR}/snappy/snappy-stubs-public.h" "${TP_INCLUDE_DIR}/snappy-stubs-public.h"
+    cp "${TP_INCLUDE_DIR}/snappy/snappy.h" "${TP_INCLUDE_DIR}/snappy.h"
+}
+
+# curl
+build_curl() {
+    check_if_source_exist "${CURL_SOURCE}"
+    cd "${TP_SOURCE_DIR}/${CURL_SOURCE}"
+
+    if [[ "${KERNEL}" != 'Darwin' ]]; then
+        libs='-lcrypto -lssl -lcrypto -ldl -static'
+    else
+        libs='-lcrypto -lssl -lcrypto -ldl'
+    fi
+
+    CPPFLAGS="-I${TP_INCLUDE_DIR} " \
+        LDFLAGS="-L${TP_LIB_DIR}" LIBS="${libs}" \
+        PKG_CONFIG="pkg-config --static" \
+        ./configure --prefix="${TP_INSTALL_DIR}" --disable-shared --enable-static \
+        --without-librtmp --with-ssl="${TP_INSTALL_DIR}" --without-libidn2 --disable-ldap --enable-ipv6 \
+        --without-libssh2 --without-brotli --without-nghttp2
+
+    make curl_LDFLAGS=-all-static -j "${PARALLEL}"
+    make curl_LDFLAGS=-all-static install
+    strip_lib libcurl.a
+}
+
+# pulsar
+build_pulsar() {
+    check_if_source_exist "${PULSAR_SOURCE}"
+
+    cd "${TP_SOURCE_DIR}"/"${PULSAR_SOURCE}"
+
+    "${CMAKE_CMD}" -DCMAKE_LIBRARY_PATH="${TP_INSTALL_DIR}"/lib -DCMAKE_INCLUDE_PATH="${TP_INSTALL_DIR}"/include \
+        -DPROTOC_PATH="${TP_INSTALL_DIR}"/bin/protoc -DBUILD_TESTS=OFF -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_DYNAMIC_LIB=OFF .
+    make -j "${PARALLEL}"
+
+    cp lib/libpulsar.a "${TP_INSTALL_DIR}"/lib/
+    cp -r include/pulsar "${TP_INSTALL_DIR}"/include/
+}
+
+if [[ "${#packages[@]}" -eq 0 ]]; then
+    packages=(
+        openssl
+        zlib
+        zstd
+        boost # must before thrift
+        gtest
+        protobuf # after gtest
+        snappy
+        curl
+        pulsar
+    )
+fi
+
+for package in "${packages[@]}"; do
+    if [[ "${package}" == "${start_package}" ]]; then
+        PACKAGE_FOUND=1
+    fi
+    if [[ "${CONTINUE}" -eq 0 ]] || [[ "${PACKAGE_FOUND}" -eq 1 ]]; then
+        command="build_${package}"
+        ${command}
+    fi
+done
+
+echo "Finished to build all thirdparties"

--- a/thirdparty/build-thirdparty-pulsar.sh
+++ b/thirdparty/build-thirdparty-pulsar.sh
@@ -421,6 +421,19 @@ build_gtest() {
 build_protobuf() {
     check_if_source_exist "${PROTOBUF_SOURCE}"
     cd "${TP_SOURCE_DIR}/${PROTOBUF_SOURCE}"
+    rm -fr gmock
+
+    # NOTE(amos): -Wl,--undefined=pthread_create force searching for pthread symbols.
+    # See https://stackoverflow.com/a/65348893/1329147 for detailed explanation.
+    mkdir gmock
+    cd gmock
+    tar xf "${TP_SOURCE_DIR}/${GTEST_NAME}"
+
+    mv "${GTEST_SOURCE}" gtest
+
+    cd "${TP_SOURCE_DIR}/${PROTOBUF_SOURCE}"
+
+    ./autogen.sh
 
     if [[ "${KERNEL}" == 'Darwin' ]]; then
         ldflags="-L${TP_LIB_DIR}"
@@ -428,20 +441,21 @@ build_protobuf() {
         ldflags="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc -Wl,--undefined=pthread_create"
     fi
 
-    mkdir -p cmake/build
-    cd cmake/build
-
-    CXXFLAGS="-O2 -I${TP_INCLUDE_DIR}" \
+    CXXFLAGS="-fPIC -O2 -I${TP_INCLUDE_DIR}" \
         LDFLAGS="${ldflags}" \
-        "${CMAKE_CMD}" -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_PREFIX_PATH="${TP_INSTALL_DIR}" \
-        -Dprotobuf_USE_EXTERNAL_GTEST=ON \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -Dprotobuf_BUILD_SHARED_LIBS=OFF \
-        -Dprotobuf_BUILD_TESTS=OFF \
-        -Dprotobuf_WITH_ZLIB_DEFAULT=ON \
-        -Dprotobuf_ABSL_PROVIDER=package \
-        -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" ../..
+        ./configure --prefix="${TP_INSTALL_DIR}" --disable-shared --enable-static --with-zlib="${TP_INSTALL_DIR}/include"
+
+    # ATTN: If protoc is not built fully statically the linktime libc may newer than runtime.
+    #       This will casue protoc cannot run
+    #       If you really need to dynamically link protoc, please set the environment variable DYN_LINK_PROTOC=1
+
+    if [[ "${DYN_LINK_PROTOC:-0}" == "1" || "${KERNEL}" == 'Darwin' ]]; then
+        echo "link protoc dynamiclly"
+    else
+        cd src
+        sed -i 's/^AM_LDFLAGS\(.*\)$/AM_LDFLAGS\1 -all-static/' Makefile
+        cd -
+    fi
 
     make -j "${PARALLEL}"
     make install

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -896,6 +896,20 @@ build_librdkafka() {
     strip_lib librdkafka++.a
 }
 
+# pulsar
+build_pulsar() {
+    check_if_source_exist $PULSAR_SOURCE
+
+    cd $TP_SOURCE_DIR/$PULSAR_SOURCE
+
+    $CMAKE_CMD -DCMAKE_LIBRARY_PATH=$TP_INSTALL_DIR/lib -DCMAKE_INCLUDE_PATH=$TP_INSTALL_DIR/include \
+        -DPROTOC_PATH=$TP_INSTALL_DIR/bin/protoc -DBUILD_TESTS=OFF -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_DYNAMIC_LIB=OFF .
+    ${BUILD_SYSTEM} -j$PARALLEL
+
+    cp lib/libpulsar.a $TP_INSTALL_DIR/lib/
+    cp -r include/pulsar $TP_INSTALL_DIR/include/
+}
+
 # libunixodbc
 build_libunixodbc() {
     check_if_source_exist "${ODBC_SOURCE}"
@@ -1647,6 +1661,7 @@ if [[ "${#packages[@]}" -eq 0 ]]; then
         krb5 # before cyrus_sasl
         cyrus_sasl
         librdkafka
+        pulsar
         flatbuffers
         orc
         arrow

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -220,6 +220,12 @@ LIBRDKAFKA_NAME=librdkafka-1.8.2.tar.gz
 LIBRDKAFKA_SOURCE=librdkafka-1.8.2
 LIBRDKAFKA_MD5SUM="0abec0888d10c9553cdcbcbf9172d558"
 
+# pulsar
+PULSAR_DOWNLOAD="https://github.com/apache/pulsar-client-cpp/archive/refs/tags/v3.3.0.tar.gz"
+PULSAR_NAME=pulsar-client-3.3.0.tar.gz
+PULSAR_SOURCE=pulsar-client-cpp-3.3.0
+PULSAR_MD5SUM="348b7e5ec39e50547668520d13a417a1"
+
 # zstd
 ZSTD_DOWNLOAD="https://github.com/facebook/zstd/releases/download/v1.5.2/zstd-1.5.2.tar.gz"
 ZSTD_NAME=zstd-1.5.2.tar.gz
@@ -492,6 +498,7 @@ export TP_ARCHIVES=(
     'ROCKSDB'
     'CYRUS_SASL'
     'LIBRDKAFKA'
+    'PULSAR'
     'FLATBUFFERS'
     'ARROW'
     'BROTLI'


### PR DESCRIPTION
1.fe侧
增加用户交互，与be的rpc调用

2.be侧
增加消费pulsar的功能
会自动丢弃无法解析的json，可能导致少量数据遗失
be节点增加静态变量 last_ack_map，保持多线程只有一份map
增加下次调度时messageid的验证避免重复录入的逻辑
增加json根据events拆分成evnet的功能

3.other
增加libpulsar.a的编译脚本
增加fe、be通用的变量、结构、rpc方法的定义

