### PR TITLE
增加实时数据过滤和非utf-8的json字符过滤

### DIFF
--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -130,7 +130,7 @@ private:
 
     size_t len_of_actual_data(const char* data);
 
-    std::vector<std::string> convert_rows(std::string& data);
+    std::vector<std::string> convert_rows(std::string& data, std::tm current_date, int64_t day);
 
     // acknowledge pulsar message
     void acknowledge(pulsar::MessageId& message_id, std::string partition);

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -140,6 +140,16 @@ private:
 
     std::vector<std::string> parse_event_ids_vector(std::shared_ptr<StreamLoadContext> ctx);
 
+    int64_t parse_diff_day_int(std::shared_ptr<StreamLoadContext> ctx);
+
+    bool isValidUTF8Char(const char c);
+
+    std::string removeNonUTF8Chars(const std::string& input);
+
+    bool isDateInRange(std::string& date_string, std::tm current_date, int64_t day);
+
+    std::tm getCurrentDate();
+
 private:
     // blocking queue to receive msgs from all consumers
     BlockingQueue<pulsar::Message*> _queue;


### PR DESCRIPTION
1.增加实时数据过滤功能
  默认非[-3,+3]的一周时间内数据无效，可通过sql调节

2.增加对存在非utf-8字符的简单过滤
  当第一次json解析失败时，试着将json中所有非utf-8字符去除，再尝试录入

